### PR TITLE
Make configurable and limit depth-search

### DIFF
--- a/install-local.sh
+++ b/install-local.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
-for path in $(find . -name "*.tar.lzma" -not -name "*-src.*"); do
+paths=$@
+
+if test -z "$paths"; then
+  paths=.
+fi
+
+for path in $(find $paths -maxdepth 2 -name "*.tar.lzma" -not -name "*-src.*"); do
     case $(basename $path) in
     *mingw32*)
         tar vxf $path -C /mingw/


### PR DESCRIPTION
Only look for mgwport packages in the direct subfolders, otherwise
we also install the packages in the mgwport folder dist a second time.

Use command line arguments to specify the source paths.

Signed-off-by: Thomas Braun thomas.braun@virtuell-zuhause.de
