### PR TITLE
Update openssl to 1.0.1h

### DIFF
--- a/mingw32-openssl/openssl-1.0.1h-1.mgwport
+++ b/mingw32-openssl/openssl-1.0.1h-1.mgwport
@@ -1,0 +1,63 @@
+DESCRIPTION="The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured, and Open Source toolkit implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) protocols as well as a full-strength general purpose cryptography library."
+HOMEPAGE="http://www.openssl.org/"
+SRC_URI="http://www.openssl.org/source/${PN}-${PV}.tar.gz
+         http://www.openssl.org/source/${PN}-${PV}.tar.gz.asc"
+
+PKG_NAMES="${PN} ${PN} ${PN} lib${PN} lib${PN}"
+
+abi=1.0.1
+abiShort=101
+
+prefix=/mingw
+openssldir=/var/ssl
+enginedir=/engines-${abi}
+
+PKG_COMPTYPES="bin doc lic dev dll-${abiShort}"
+
+PKG_CONTENTS[0]="bin
+                 --exclude=bin/*.dll
+                 var/ssl"
+PKG_CONTENTS[1]="share/man/man[157] share/doc
+                 --exclude share/doc/${PN}/${PV}/LICENSE"
+PKG_CONTENTS[2]="share/doc/${PN}/${PV}/LICENSE"
+PKG_CONTENTS[3]="include lib/lib*.a share/man/man3 lib/pkgconfig"
+PKG_CONTENTS[4]="bin/*.dll lib/openssl${enginedir}"
+
+CONF_ARGS="--prefix=${D}${prefix} \
+           --openssldir=${prefix}${openssldir} \
+           --enginesdir=${prefix}/lib/openssl/${enginedir} \
+           enable-zlib-dynamic enable-threads enable-shared"
+
+PATCH_URI="01-mingw32-initial.mingw32.patch
+           01-msys-initial.msys.patch
+           02-mingw32-eay-to-nix.mingw32.patch
+           04-mingw32-debug.mingw32.patch
+           11-Cope-better-with-DOS-line-endings.mingw32.patch
+           13-Make-sure-that-we-use-cmd-as-a-shell.mingw32.patch
+           14-openssl-build-DLL-directly.mingw32.patch
+           15-generate-import-lib.mingw32.patch
+           16-do-not-specify-march-i486.mingw32.patch
+           openssl-0.9.6-x509.all.patch
+           openssl-0.9.7-beta5-version-add-engines.all.patch
+           openssl-0.9.8a-enginesdir.patch-1.0.0.all.patch
+           openssl-0.9.8-beta6-icpbrasil.all.patch
+           openssl-0.9.8a-defaults.patch-1.0.0.all.patch
+           openssl-0.9.8e-crt.all.patch
+           openssl-1.0.0e-enginesdir-install.all.patch"
+
+src_compile() {
+  lndirs
+  cd ${B}
+  ./config ${CONF_ARGS}
+  mgwmake
+}
+
+src_test() {
+  cd ${B}
+  make tests
+}
+
+src_install() {
+  cd ${B}
+  make install MANDIR=${prefix}/share/man INSTALL_PREFIX=${D} MANSUFFIX=ssl
+}

--- a/msys-openssl/openssl-1.0.1h-1.msysport
+++ b/msys-openssl/openssl-1.0.1h-1.msysport
@@ -1,0 +1,59 @@
+DESCRIPTION="The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured, and Open Source toolkit implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) protocols as well as a full-strength general purpose cryptography library."
+HOMEPAGE="http://www.openssl.org"
+SRC_URI="http://www.openssl.org/source/${PN}-${PV}.tar.gz
+         http://www.openssl.org/source/${PN}-${PV}.tar.gz.asc"
+
+PKG_NAMES="${PN} ${PN} ${PN} lib${PN} lib${PN}"
+
+abi=1.0.1
+abiShort=101
+
+prefix=/usr
+openssldir=/var/ssl
+enginedir=/engines-${abi}
+
+PKG_COMPTYPES="bin doc lic dev dll-${abiShort}"
+
+PKG_CONTENTS[0]="bin
+                 --exclude=bin/*.dll
+                 var/ssl"
+PKG_CONTENTS[1]="share/man/man[157] share/doc
+                 --exclude share/doc/${PN}/${PV}/LICENSE"
+PKG_CONTENTS[2]="share/doc/${PN}/${PV}/LICENSE"
+PKG_CONTENTS[3]="include lib/lib*.a share/man/man3 lib/pkgconfig"
+PKG_CONTENTS[4]="bin/*.dll lib/openssl${enginedir}"
+
+MAKEOPTS=-j1
+
+CONF_ARGS="--prefix=${D}${prefix} \
+           --openssldir=${openssldir} \
+           --enginesdir=${prefix}/lib/openssl${enginedir} \
+           enable-zlib enable-threads enable-shared"
+
+PATCH_URI="01-msys-initial.msys.patch
+           do-not-specify-march-i486.msys.patch
+           openssl-0.9.6-x509.all.patch
+           openssl-0.9.7-beta5-version-add-engines.all.patch
+           openssl-0.9.8a-enginesdir.patch-1.0.0.all.patch
+           openssl-0.9.8-beta6-icpbrasil.all.patch
+           openssl-0.9.8a-defaults.patch-1.0.0.all.patch
+           openssl-0.9.8e-crt.all.patch
+           openssl-1.0.0e-enginesdir-install.all.patch
+           openssl-1.0.0j-enginesdir-install.msys.patch"
+
+src_compile() {
+  lndirs
+  cd ${B}
+  ./config ${CONF_ARGS}
+  mgwmake
+}
+
+src_test() {
+  cd ${B}
+  mgwmake tests
+}
+
+src_install() {
+  cd ${B}
+  mgwmake install MANDIR=${prefix}/share/man INSTALL_PREFIX=${D} MANSUFFIX=ssl
+}


### PR DESCRIPTION
OpenSSL 1.0.1h fixes several vulnerabilities, including some
client-side.
See https://www.openssl.org/news/secadv_20140605.txt

These compile cleanly, although the new versions would need to be uploaded to the webserver.
