### PR TITLE
Add Unicode support to msys-core

### DIFF
--- a/msys-core/0014-msys.dll-support-Unicode-console-input.patch
+++ b/msys-core/0014-msys.dll-support-Unicode-console-input.patch
@@ -1,0 +1,94 @@
+From ddcfdc189bfc751c226962ace8c5812ba666b0b2 Mon Sep 17 00:00:00 2001
+From: Karsten Blees <blees@dcon.de>
+Date: Thu, 5 Jul 2012 10:18:33 +0200
+Subject: [PATCH 14/17] msys.dll: support Unicode console input
+
+The msys.dll console handler still uses Windows system encoding for console
+input, while everything else in msys.dll has been switched to UTF-8.
+
+Use ReadConsoleInputW for console input and convert from UTF-16 to UTF-8.
+
+Limitations: the current implementation doesn't support UTF-16 surrogate
+pairs. I don't know if its even possible to enter CJK extended chars (i.e.
+> \u0ffff) on a keyboard, and I have no way to test this.
+
+Signed-off-by: Karsten Blees <blees@dcon.de>
+---
+ msys/rt/src/winsup/cygwin/fhandler_console.cc |   26 +++++++++++++++----------
+ 1 file changed, 16 insertions(+), 10 deletions(-)
+
+diff --git a/msys/rt/src/winsup/cygwin/fhandler_console.cc b/msys/rt/src/winsup/cygwin/fhandler_console.cc
+index 233bf09..724db03 100644
+--- a/msys/rt/src/winsup/cygwin/fhandler_console.cc
++++ b/msys/rt/src/winsup/cygwin/fhandler_console.cc
+@@ -258,7 +258,7 @@ fhandler_console::read (void *pv, size_t buflen)
+       INPUT_RECORD input_rec;
+       const char *toadd = NULL;
+ 
+-      if (!ReadConsoleInput (h, &input_rec, 1, &nread))
++      if (!ReadConsoleInputW (h, &input_rec, 1, &nread))
+ 	{
+ 	  __seterrno ();
+ 	  syscall_printf ("ReadConsoleInput failed, %E");
+@@ -301,7 +301,6 @@ fhandler_console::read (void *pv, size_t buflen)
+ 	  if (!input_rec.Event.KeyEvent.bKeyDown)
+ 	    continue;
+ 
+-#define ich (input_rec.Event.KeyEvent.uChar.AsciiChar)
+ #define wch (input_rec.Event.KeyEvent.uChar.UnicodeChar)
+ #define ALT_PRESSED (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)
+ #define CTRL_PRESSED (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)
+@@ -317,11 +316,20 @@ fhandler_console::read (void *pv, size_t buflen)
+ 	    }
+ 	  else
+ 	    {
+-	      tmp[1] = ich;
+-	      /* Need this check since US code page seems to have a bug when
+-		 converting a CTRL-U. */
+-	      if ((unsigned char)ich > 0x7f)
+-		con_to_str (tmp + 1, tmp + 1, 1);
++	      if (wch < 0x80)
++		{
++		  tmp[1] = wch;
++		}
++	      else
++		{
++		  wchar_t wtmp[2];
++		  wtmp[0] = wch;
++		  wtmp[1] = 0;
++		  int len = wcstoutf(&tmp[1], wtmp, sizeof(tmp) - 1);
++		  if (len < 0)
++		    return -1;
++		  nread = (unsigned int) len;
++		}
+ 	      /* Determine if the keystroke is modified by META.  The tricky
+ 		 part is to distinguish whether the right Alt key should be
+ 		 recognized as Alt, or as AltGr. */
+@@ -332,7 +340,7 @@ fhandler_console::read (void *pv, size_t buflen)
+ 		   an ASCII control character, interpret is as META. */
+ 		meta = (control_key_state & ALT_PRESSED) != 0
+ 		       && ((control_key_state & CTRL_PRESSED) == 0
+-			   || (ich >= 0 && ich <= 0x1f || ich == 0x7f));
++			   || (wch <= 0x1f || wch == 0x7f));
+ 	      else
+ 		/* Win9x: there's no way to distinguish Alt from AltGr, so rely
+ 		   on meta_mask heuristic (see fhandler_console constructor). */
+@@ -347,7 +355,6 @@ fhandler_console::read (void *pv, size_t buflen)
+ 		  nread++;
+ 		}
+ 	    }
+-#undef ich
+ #undef wch
+ #undef ALT_PRESSED
+ #undef CTRL_PRESSED
+@@ -454,7 +461,6 @@ fhandler_console::read (void *pv, size_t buflen)
+ 	  else if (res)
+ 	    break;
+ 	}
+-#undef ich
+     }
+ 
+   while (buflen)
+-- 
+1.7.10.rc1.5708.g87c2b
+

--- a/msys-core/0015-msys.dll-support-ALT-NUMPAD-console-input.patch
+++ b/msys-core/0015-msys.dll-support-ALT-NUMPAD-console-input.patch
@@ -1,0 +1,36 @@
+From 7b8855233c0c969463384d5ec8b3a8b4e7f70a31 Mon Sep 17 00:00:00 2001
+From: Karsten Blees <blees@dcon.de>
+Date: Thu, 5 Jul 2012 10:27:11 +0200
+Subject: [PATCH 15/17] msys.dll: support ALT+NUMPAD console input
+
+The msys console handler currently ignores all key up events.
+
+Support ALT+NUMPAD console input by accepting characters transfered in key
+up events of the ALT (VK_MENU) key.
+
+Signed-off-by: Karsten Blees <blees@dcon.de>
+---
+ msys/rt/src/winsup/cygwin/fhandler_console.cc |    5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/msys/rt/src/winsup/cygwin/fhandler_console.cc b/msys/rt/src/winsup/cygwin/fhandler_console.cc
+index 724db03..1c3de60 100644
+--- a/msys/rt/src/winsup/cygwin/fhandler_console.cc
++++ b/msys/rt/src/winsup/cygwin/fhandler_console.cc
+@@ -298,10 +298,11 @@ fhandler_console::read (void *pv, size_t buflen)
+ 	      break;
+ 	    }
+ 
+-	  if (!input_rec.Event.KeyEvent.bKeyDown)
++#define wch (input_rec.Event.KeyEvent.uChar.UnicodeChar)
++
++	  if (!input_rec.Event.KeyEvent.bKeyDown && (wch == 0 || virtual_key_code != VK_MENU))
+ 	    continue;
+ 
+-#define wch (input_rec.Event.KeyEvent.uChar.UnicodeChar)
+ #define ALT_PRESSED (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)
+ #define CTRL_PRESSED (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)
+ 
+-- 
+1.7.10.rc1.5708.g87c2b
+

--- a/msys-core/0016-msys.dll-backport-multibyte-support-functions-from-n.patch
+++ b/msys-core/0016-msys.dll-backport-multibyte-support-functions-from-n.patch
@@ -1,0 +1,17731 @@
+From 2833c7769e59579d9ae7dc05f928a83817c54e2a Mon Sep 17 00:00:00 2001
+From: Karsten Blees <blees@dcon.de>
+Date: Thu, 5 Jul 2012 10:52:45 +0200
+Subject: [PATCH 16/17] msys.dll: backport multibyte support functions from
+ newlib 1.20
+
+Unicode/UTF-8 support in bash and other utilities is based on the POSIX
+multibyte / wide char conversion functions (mbtowc, wctomb etc.).
+Msys.dll's newlib 1.9 only has a few mock implementations that essentially
+do nothing, so that bash cannot even be configured with multibyte support
+enabled.
+
+Backport the multibyte / wide char conversion functions from the current
+newlib 1.20 library.
+
+Most of the implementation files can be copied verbatim, with occasional
+"#ifdef __CYGWIN__" replaced by "#if defined(__CYGWIN__) ||
+defined(__MSYS__)".
+
+Besides adding wchar.h and wctype.h from newlib 1.20, a few minor changes
+to the header files are necessary, most notably adding some state variables
+to the _reent structure.
+
+Finally, add the new functions and files to cygwin.din and Makefile.in so
+that they are available in the msys.dll.
+
+Signed-off-by: Karsten Blees <blees@dcon.de>
+---
+ msys/rt/src/newlib/configure.host            |    2 +-
+ msys/rt/src/newlib/libc/ctype/Makefile.in    |   30 +-
+ msys/rt/src/newlib/libc/ctype/iswalnum.c     |   37 +
+ msys/rt/src/newlib/libc/ctype/iswalpha.c     |  433 ++
+ msys/rt/src/newlib/libc/ctype/iswblank.c     |   82 +
+ msys/rt/src/newlib/libc/ctype/iswcntrl.c     |   80 +
+ msys/rt/src/newlib/libc/ctype/iswctype.c     |   71 +
+ msys/rt/src/newlib/libc/ctype/iswdigit.c     |   37 +
+ msys/rt/src/newlib/libc/ctype/iswgraph.c     |   66 +
+ msys/rt/src/newlib/libc/ctype/iswlower.c     |   38 +
+ msys/rt/src/newlib/libc/ctype/iswprint.c     |  496 ++
+ msys/rt/src/newlib/libc/ctype/iswpunct.c     |   70 +
+ msys/rt/src/newlib/libc/ctype/iswspace.c     |   83 +
+ msys/rt/src/newlib/libc/ctype/iswupper.c     |   38 +
+ msys/rt/src/newlib/libc/ctype/iswxdigit.c    |   39 +
+ msys/rt/src/newlib/libc/ctype/jp2uc.c        |  166 +
+ msys/rt/src/newlib/libc/ctype/jp2uc.h        | 6849 ++++++++++++++++++++++++++
+ msys/rt/src/newlib/libc/ctype/local.h        |   32 +
+ msys/rt/src/newlib/libc/ctype/towctrans.c    |   97 +
+ msys/rt/src/newlib/libc/ctype/towlower.c     |  569 +++
+ msys/rt/src/newlib/libc/ctype/towupper.c     |  590 +++
+ msys/rt/src/newlib/libc/ctype/utf8alpha.h    |  355 ++
+ msys/rt/src/newlib/libc/ctype/utf8print.h    |  389 ++
+ msys/rt/src/newlib/libc/ctype/wctrans.c      |   94 +
+ msys/rt/src/newlib/libc/ctype/wctype.c       |  137 +
+ msys/rt/src/newlib/libc/include/newlib.h     |    5 +
+ msys/rt/src/newlib/libc/include/stdlib.h     |   10 +-
+ msys/rt/src/newlib/libc/include/sys/_types.h |   50 +
+ msys/rt/src/newlib/libc/include/sys/errno.h  |    1 +
+ msys/rt/src/newlib/libc/include/sys/reent.h  |   24 +-
+ msys/rt/src/newlib/libc/include/wchar.h      |  199 +
+ msys/rt/src/newlib/libc/include/wctype.h     |   51 +
+ msys/rt/src/newlib/libc/locale/locale.c      |   16 +-
+ msys/rt/src/newlib/libc/stdlib/Makefile.in   |   16 +-
+ msys/rt/src/newlib/libc/stdlib/local.h       |   58 +
+ msys/rt/src/newlib/libc/stdlib/mbctype.h     |    3 +-
+ msys/rt/src/newlib/libc/stdlib/mblen.c       |   42 +-
+ msys/rt/src/newlib/libc/stdlib/mblen_r.c     |   37 +-
+ msys/rt/src/newlib/libc/stdlib/mbrlen.c      |   20 +
+ msys/rt/src/newlib/libc/stdlib/mbrtowc.c     |   79 +
+ msys/rt/src/newlib/libc/stdlib/mbsinit.c     |   14 +
+ msys/rt/src/newlib/libc/stdlib/mbsnrtowcs.c  |  179 +
+ msys/rt/src/newlib/libc/stdlib/mbsrtowcs.c   |   29 +
+ msys/rt/src/newlib/libc/stdlib/mbstowcs.c    |   45 +-
+ msys/rt/src/newlib/libc/stdlib/mbstowcs_r.c  |   31 +-
+ msys/rt/src/newlib/libc/stdlib/mbtowc.c      |   46 +-
+ msys/rt/src/newlib/libc/stdlib/mbtowc_r.c    |  742 ++-
+ msys/rt/src/newlib/libc/stdlib/wcrtomb.c     |   78 +
+ msys/rt/src/newlib/libc/stdlib/wcsnrtombs.c  |  185 +
+ msys/rt/src/newlib/libc/stdlib/wcsrtombs.c   |   26 +
+ msys/rt/src/newlib/libc/stdlib/wcstod.c      |  230 +
+ msys/rt/src/newlib/libc/stdlib/wcstol.c      |  226 +
+ msys/rt/src/newlib/libc/stdlib/wcstold.c     |   42 +
+ msys/rt/src/newlib/libc/stdlib/wcstoll.c     |  138 +
+ msys/rt/src/newlib/libc/stdlib/wcstoll_r.c   |  140 +
+ msys/rt/src/newlib/libc/stdlib/wcstombs.c    |   51 +-
+ msys/rt/src/newlib/libc/stdlib/wcstombs_r.c  |   46 +-
+ msys/rt/src/newlib/libc/stdlib/wcstoul.c     |  207 +
+ msys/rt/src/newlib/libc/stdlib/wcstoull.c    |  140 +
+ msys/rt/src/newlib/libc/stdlib/wcstoull_r.c  |  130 +
+ msys/rt/src/newlib/libc/stdlib/wctob.c       |   24 +
+ msys/rt/src/newlib/libc/stdlib/wctomb.c      |   30 +-
+ msys/rt/src/newlib/libc/stdlib/wctomb_r.c    |  437 +-
+ msys/rt/src/newlib/libc/string/Makefile.in   |   30 +-
+ msys/rt/src/newlib/libc/string/local.h       |   12 +
+ msys/rt/src/newlib/libc/string/wcscasecmp.c  |   56 +
+ msys/rt/src/newlib/libc/string/wcscat.c      |   85 +
+ msys/rt/src/newlib/libc/string/wcschr.c      |   82 +
+ msys/rt/src/newlib/libc/string/wcscmp.c      |   83 +
+ msys/rt/src/newlib/libc/string/wcscoll.c     |   48 +
+ msys/rt/src/newlib/libc/string/wcscpy.c      |   79 +
+ msys/rt/src/newlib/libc/string/wcsdup.c      |   62 +
+ msys/rt/src/newlib/libc/string/wcslen.c      |   72 +
+ msys/rt/src/newlib/libc/string/wcsncasecmp.c |   64 +
+ msys/rt/src/newlib/libc/string/wcsncat.c     |   91 +
+ msys/rt/src/newlib/libc/string/wcsncmp.c     |   91 +
+ msys/rt/src/newlib/libc/string/wcsncpy.c     |   58 +
+ msys/rt/src/newlib/libc/string/wcsrchr.c     |   88 +
+ msys/rt/src/newlib/libc/string/wcswidth.c    |   73 +
+ msys/rt/src/newlib/libc/string/wcwidth.c     |  346 ++
+ msys/rt/src/newlib/libc/string/wmemchr.c     |   89 +
+ msys/rt/src/newlib/libc/string/wmemcmp.c     |   89 +
+ msys/rt/src/newlib/libc/string/wmemcpy.c     |   76 +
+ msys/rt/src/newlib/libc/string/wmemmove.c    |   82 +
+ msys/rt/src/newlib/libc/string/wmemset.c     |   82 +
+ msys/rt/src/winsup/cygwin/cygwin.din         |   47 +
+ msys/rt/src/winsup/cygwin/include/limits.h   |    2 +-
+ 87 files changed, 16212 insertions(+), 382 deletions(-)
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswalnum.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswalpha.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswblank.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswcntrl.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswctype.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswdigit.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswgraph.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswlower.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswprint.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswpunct.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswspace.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswupper.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/iswxdigit.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/jp2uc.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/jp2uc.h
+ create mode 100644 msys/rt/src/newlib/libc/ctype/local.h
+ create mode 100644 msys/rt/src/newlib/libc/ctype/towctrans.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/towlower.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/towupper.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/utf8alpha.h
+ create mode 100644 msys/rt/src/newlib/libc/ctype/utf8print.h
+ create mode 100644 msys/rt/src/newlib/libc/ctype/wctrans.c
+ create mode 100644 msys/rt/src/newlib/libc/ctype/wctype.c
+ create mode 100644 msys/rt/src/newlib/libc/include/newlib.h
+ create mode 100644 msys/rt/src/newlib/libc/include/wchar.h
+ create mode 100644 msys/rt/src/newlib/libc/include/wctype.h
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/mbrlen.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/mbrtowc.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/mbsinit.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/mbsnrtowcs.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/mbsrtowcs.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcrtomb.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcsnrtombs.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcsrtombs.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstod.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstol.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstold.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstoll.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstoll_r.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstoul.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstoull.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wcstoull_r.c
+ create mode 100644 msys/rt/src/newlib/libc/stdlib/wctob.c
+ create mode 100644 msys/rt/src/newlib/libc/string/local.h
+ create mode 100644 msys/rt/src/newlib/libc/string/wcscasecmp.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcscat.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcschr.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcscmp.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcscoll.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcscpy.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcsdup.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcslen.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcsncasecmp.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcsncat.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcsncmp.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcsncpy.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcsrchr.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcswidth.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wcwidth.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wmemchr.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wmemcmp.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wmemcpy.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wmemmove.c
+ create mode 100644 msys/rt/src/newlib/libc/string/wmemset.c
+
+diff --git a/msys/rt/src/newlib/configure.host b/msys/rt/src/newlib/configure.host
+index 29acad6..2cc8d2f 100644
+--- a/msys/rt/src/newlib/configure.host
++++ b/msys/rt/src/newlib/configure.host
+@@ -189,7 +189,7 @@ esac
+ # Enable multibyte support if requested.
+ 
+ if [ "${newlib_mb}" = "yes" ] ; then
+-	newlib_cflags="${newlib_cflags} -DMB_CAPABLE"
++	newlib_cflags="${newlib_cflags} -DMB_CAPABLE -D_MB_CAPABLE"
+ fi
+ 
+ # Get the source directories to use for the host.  unix_dir is set
+diff --git a/msys/rt/src/newlib/libc/ctype/Makefile.in b/msys/rt/src/newlib/libc/ctype/Makefile.in
+index 17a4f8d..d3d98ad 100644
+--- a/msys/rt/src/newlib/libc/ctype/Makefile.in
++++ b/msys/rt/src/newlib/libc/ctype/Makefile.in
+@@ -105,7 +105,28 @@ lib_a_SOURCES = \
+ 	tolower.c \
+ 	toupper.c \
+ 	_tolower.c \
+-	_toupper.c
++	_toupper.c \
++	iswalnum.c \
++	iswblank.c \
++	iswctype.c \
++	iswgraph.c \
++	iswprint.c \
++	iswspace.c \
++	iswxdigit.c \
++	iswalpha.c \
++	iswcntrl.c \
++	iswdigit.c \
++	iswlower.c \
++	iswpunct.c \
++	iswupper.c \
++	jp2uc.c \
++	towctrans.c \
++	towlower.c \
++	towupper.c \
++	wctrans.c \
++	wctype.c
++
++
+ 
+ 
+ CHEWOUT_FILES = \
+@@ -144,7 +165,12 @@ LIBS = @LIBS@
+ lib_a_LIBADD = 
+ lib_a_OBJECTS =  ctype_.o isalnum.o isalpha.o isascii.o iscntrl.o \
+ isdigit.o islower.o isupper.o isprint.o ispunct.o isspace.o isxdigit.o \
+-toascii.o tolower.o toupper.o _tolower.o _toupper.o
++toascii.o tolower.o toupper.o _tolower.o _toupper.o iswalnum.o iswblank.o \
++iswctype.o iswgraph.o iswprint.o iswspace.o iswxdigit.o iswalpha.o \
++iswcntrl.o iswdigit.o iswlower.o iswpunct.o iswupper.o jp2uc.o \
++towctrans.o towlower.o towupper.o wctrans.o wctype.o
++
++
+ CFLAGS = @CFLAGS@
+ COMPILE = $(CC) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+ CCLD = $(CC)
+diff --git a/msys/rt/src/newlib/libc/ctype/iswalnum.c b/msys/rt/src/newlib/libc/ctype/iswalnum.c
+new file mode 100644
+index 0000000..c417cb3
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswalnum.c
+@@ -0,0 +1,37 @@
++/*
++FUNCTION
++	<<iswalnum>>---alphanumeric wide character test
++
++INDEX
++	iswalnum
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswalnum(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswalnum(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswalnum>> is a function which classifies wide-character values that
++are alphanumeric.
++
++RETURNS
++<<iswalnum>> returns non-zero if <[c]> is a alphanumeric wide character.
++
++PORTABILITY
++<<iswalnum>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <wctype.h>
++
++int
++_DEFUN(iswalnum,(c),wint_t c)
++{
++  return (iswalpha (c) || iswdigit (c));
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswalpha.c b/msys/rt/src/newlib/libc/ctype/iswalpha.c
+new file mode 100644
+index 0000000..16d4240
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswalpha.c
+@@ -0,0 +1,433 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<iswalpha>>---alphabetic wide character test
++
++INDEX
++	iswalpha
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswalpha(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswalpha(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswalpha>> is a function which classifies wide-character values that
++are alphabetic.
++
++RETURNS
++<<iswalpha>> returns non-zero if <[c]> is an alphabetic wide character.
++
++PORTABILITY
++<<iswalpha>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <newlib.h>
++#include <wctype.h>
++#include <string.h>
++#include <ctype.h>
++#include "local.h"
++
++#ifdef _MB_CAPABLE
++#include "utf8alpha.h"
++#endif /* _MB_CAPABLE */
++
++int
++_DEFUN(iswalpha,(c), wint_t c)
++{
++#ifdef _MB_CAPABLE
++  unsigned const char *table;
++  unsigned char *ptr;
++  unsigned char ctmp;
++  int size;
++  wint_t x;
++
++  c = _jp2uc (c);
++
++  /* Based on and tested against Unicode 5.2
++     See utf8alpha.h for a description how to fetch the data. */
++  x = (c >> 8);
++  /* for some large sections, all characters are alphabetic so handle them here */
++  if ((x >= 0x34 && x <= 0x4c) ||
++      (x >= 0x4e && x <= 0x9e) ||
++      (x >= 0xac && x <= 0xd6) ||
++      (x >= 0x120 && x <= 0x122) ||
++      (x >= 0x130 && x <= 0x133) ||
++      (x >= 0x200 && x <= 0x2a5) ||
++      (x >= 0x2a7 && x <= 0x2b6))
++    return 1;
++  
++  switch (x)
++    {
++    case 0x00:
++      table = u0;
++      size = sizeof(u0);
++      break;
++    case 0x01:
++    case 0x11:
++    case 0x15:
++    case 0x1e:
++    case 0xa0:
++    case 0xa1:
++    case 0xa2:
++    case 0xa3:
++    case 0xa5:
++    case 0xf9:
++    case 0xfc:
++    case 0x2f8:
++    case 0x2f9:
++      return 1;
++    case 0x02:
++      table = u2;
++      size = sizeof(u2);
++      break;
++    case 0x03:
++      table = u3;
++      size = sizeof(u3);
++      break;
++    case 0x04:
++      table = u4;
++      size = sizeof(u4);
++      break;
++    case 0x05:
++      table = u5;
++      size = sizeof(u5);
++      break;
++    case 0x06:
++      table = u6;
++      size = sizeof(u6);
++      break;
++    case 0x07:
++      table = u7;
++      size = sizeof(u7);
++      break;
++    case 0x08:
++      table = u8;
++      size = sizeof(u8);
++      break;
++    case 0x09:
++      table = u9;
++      size = sizeof(u9);
++      break;
++    case 0x0a:
++      table = ua;
++      size = sizeof(ua);
++      break;
++    case 0x0b:
++      table = ub;
++      size = sizeof(ub);
++      break;
++    case 0x0c:
++      table = uc;
++      size = sizeof(uc);
++      break;
++    case 0x0d:
++      table = ud;
++      size = sizeof(ud);
++      break;
++    case 0x0e:
++      table = ue;
++      size = sizeof(ue);
++      break;
++    case 0x0f:
++      table = uf;
++      size = sizeof(uf);
++      break;
++    case 0x10:
++      table = u10;
++      size = sizeof(u10);
++      break;
++    case 0x12:
++      table = u12;
++      size = sizeof(u12);
++      break;
++    case 0x13:
++      table = u13;
++      size = sizeof(u13);
++      break;
++    case 0x14:
++      table = u14;
++      size = sizeof(u14);
++      break;
++    case 0x16:
++      table = u16;
++      size = sizeof(u16);
++      break;
++    case 0x17:
++      table = u17;
++      size = sizeof(u17);
++      break;
++    case 0x18:
++      table = u18;
++      size = sizeof(u18);
++      break;
++    case 0x19:
++      table = u19;
++      size = sizeof(u19);
++      break;
++    case 0x1a:
++      table = u1a;
++      size = sizeof(u1a);
++      break;
++    case 0x1b:
++      table = u1b;
++      size = sizeof(u1b);
++      break;
++    case 0x1c:
++      table = u1c;
++      size = sizeof(u1c);
++      break;
++    case 0x1d:
++      table = u1d;
++      size = sizeof(u1d);
++      break;
++    case 0x1f:
++      table = u1f;
++      size = sizeof(u1f);
++      break;
++    case 0x20:
++      table = u20;
++      size = sizeof(u20);
++      break;
++    case 0x21:
++      table = u21;
++      size = sizeof(u21);
++      break;
++    case 0x24:
++      table = u24;
++      size = sizeof(u24);
++      break;
++    case 0x2c:
++      table = u2c;
++      size = sizeof(u2c);
++      break;
++    case 0x2d:
++      table = u2d;
++      size = sizeof(u2d);
++      break;
++    case 0x2e:
++      table = u2e;
++      size = sizeof(u2e);
++      break;
++    case 0x30:
++      table = u30;
++      size = sizeof(u30);
++      break;
++    case 0x31:
++      table = u31;
++      size = sizeof(u31);
++      break;
++    case 0x4d:
++      table = u4d;
++      size = sizeof(u4d);
++      break;
++    case 0x9f:
++      table = u9f;
++      size = sizeof(u9f);
++      break;
++    case 0xa4:
++      table = ua4;
++      size = sizeof(ua4);
++      break;
++    case 0xa6:
++      table = ua6;
++      size = sizeof(ua6);
++      break;
++    case 0xa7:
++      table = ua7;
++      size = sizeof(ua7);
++      break;
++    case 0xa8:
++      table = ua8;
++      size = sizeof(ua8);
++      break;
++    case 0xa9:
++      table = ua9;
++      size = sizeof(ua9);
++      break;
++    case 0xaa:
++      table = uaa;
++      size = sizeof(uaa);
++      break;
++    case 0xab:
++      table = uab;
++      size = sizeof(uab);
++      break;
++    case 0xd7:
++      table = ud7;
++      size = sizeof(ud7);
++      break;
++    case 0xfa:
++      table = ufa;
++      size = sizeof(ufa);
++      break;
++    case 0xfb:
++      table = ufb;
++      size = sizeof(ufb);
++      break;
++    case 0xfd:
++      table = ufd;
++      size = sizeof(ufd);
++      break;
++    case 0xfe:
++      table = ufe;
++      size = sizeof(ufe);
++      break;
++    case 0xff:
++      table = uff;
++      size = sizeof(uff);
++      break;
++    case 0x100:
++      table = u100;
++      size = sizeof(u100);
++      break;
++    case 0x101:
++      table = u101;
++      size = sizeof(u101);
++      break;
++    case 0x102:
++      table = u102;
++      size = sizeof(u102);
++      break;
++    case 0x103:
++      table = u103;
++      size = sizeof(u103);
++      break;
++    case 0x104:
++      table = u104;
++      size = sizeof(u104);
++      break;
++    case 0x108:
++      table = u108;
++      size = sizeof(u108);
++      break;
++    case 0x109:
++      table = u109;
++      size = sizeof(u109);
++      break;
++    case 0x10a:
++      table = u10a;
++      size = sizeof(u10a);
++      break;
++    case 0x10b:
++      table = u10b;
++      size = sizeof(u10b);
++      break;
++    case 0x10c:
++      table = u10c;
++      size = sizeof(u10c);
++      break;
++    case 0x110:
++      table = u110;
++      size = sizeof(u110);
++      break;
++    case 0x123:
++      table = u123;
++      size = sizeof(u123);
++      break;
++    case 0x124:
++      table = u124;
++      size = sizeof(u124);
++      break;
++    case 0x134:
++      table = u134;
++      size = sizeof(u134);
++      break;
++    case 0x1d4:
++      table = u1d4;
++      size = sizeof(u1d4);
++      break;
++    case 0x1d5:
++      table = u1d5;
++      size = sizeof(u1d5);
++      break;
++    case 0x1d6:
++      table = u1d6;
++      size = sizeof(u1d6);
++      break;
++    case 0x1d7:
++      table = u1d7;
++      size = sizeof(u1d7);
++      break;
++    case 0x1f1:
++      table = u1f1;
++      size = sizeof(u1f1);
++      break;
++    case 0x2a6:
++      table = u2a6;
++      size = sizeof(u2a6);
++      break;
++    case 0x2b7:
++      table = u2b7;
++      size = sizeof(u2b7);
++      break;
++    case 0x2fa:
++      table = u2fa;
++      size = sizeof(u2fa);
++      break;
++    default:
++      return 0;
++    }
++  /* we have narrowed down to a section of 256 characters to check */
++  /* now check if c matches the alphabetic wide-chars within that section */
++  ptr = (unsigned char *)table;
++  ctmp = (unsigned char)c;
++  while (ptr < table + size)
++    {
++      if (ctmp == *ptr)
++	return 1;
++      if (ctmp < *ptr)
++	return 0;
++      /* otherwise c > *ptr */
++      /* look for 0x0 as next element which indicates a range */
++      ++ptr;
++      if (*ptr == 0x0)
++	{
++	  /* we have a range..see if c falls within range */
++	  ++ptr;
++	  if (ctmp <= *ptr)
++	    return 1;
++	  ++ptr;
++	}
++    }
++  /* not in table */
++  return 0;
++#else
++  return (c < (wint_t)0x100 ? isalpha (c) : 0);
++#endif /* _MB_CAPABLE */
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswblank.c b/msys/rt/src/newlib/libc/ctype/iswblank.c
+new file mode 100644
+index 0000000..7ca2b62
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswblank.c
+@@ -0,0 +1,82 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<iswblank>>---blank wide character test
++
++INDEX
++	iswblank
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswblank(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswblank(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswblank>> is a function which classifies wide-character values that
++are categorized as blank.
++
++RETURNS
++<<iswblank>> returns non-zero if <[c]> is a blank wide character.
++
++PORTABILITY
++<<iswblank>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <newlib.h>
++#include <wctype.h>
++#include <ctype.h>
++#include <string.h>
++#include "local.h"
++
++int
++_DEFUN(iswblank,(c), wint_t c)
++{
++#ifdef _MB_CAPABLE
++  c = _jp2uc (c);
++  /* Based on Unicode 5.2.  Control char 09, plus all characters
++     from general category "Zs", which are not marked as decomposition
++     type "noBreak". */
++  return (c == 0x0009 || c == 0x0020 ||
++	  c == 0x1680 || c == 0x180e ||
++	  (c >= 0x2000 && c <= 0x2006) ||
++	  (c >= 0x2008 && c <= 0x200a) ||
++	  c == 0x205f || c == 0x3000);
++#else
++  return (c < 0x100 ? isblank (c) : 0);
++#endif /* _MB_CAPABLE */
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswcntrl.c b/msys/rt/src/newlib/libc/ctype/iswcntrl.c
+new file mode 100644
+index 0000000..05b3ea9
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswcntrl.c
+@@ -0,0 +1,80 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<iswcntrl>>---control wide character test
++
++INDEX
++	iswcntrl
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswcntrl(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswcntrl(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswcntrl>> is a function which classifies wide-character values that
++are categorized as control characters.
++
++RETURNS
++<<iswcntrl>> returns non-zero if <[c]> is a control wide character.
++
++PORTABILITY
++<<iswcntrl>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <newlib.h>
++#include <wctype.h>
++#include <ctype.h>
++#include <string.h>
++#include "local.h"
++
++int
++_DEFUN(iswcntrl,(c), wint_t c)
++{
++#ifdef _MB_CAPABLE
++  c = _jp2uc (c);
++
++  /* Based on Unicode 5.2.  All characters from general category "Cc", "Zl",
++     and "Zp".  */
++  return ((c >= 0x0000 && c <= 0x001f) || 
++	  (c >= 0x007f && c <= 0x009f) ||
++	  c == 0x2028 || c == 0x2029);
++#else
++  return (c < 0x100 ? iscntrl (c) : 0);
++#endif /* _MB_CAPABLE */
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswctype.c b/msys/rt/src/newlib/libc/ctype/iswctype.c
+new file mode 100644
+index 0000000..3f3eadf
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswctype.c
+@@ -0,0 +1,71 @@
++/*
++FUNCTION
++	<<iswctype>>---extensible wide-character test
++
++INDEX
++	iswctype
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswctype(wint_t <[c]>, wctype_t <[desc]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswctype(<[c]>, <[desc]>)
++	wint_t <[c]>;
++	wctype_t <[desc]>;
++
++DESCRIPTION
++<<iswctype>> is a function which classifies wide-character values using the
++wide-character test specified by <[desc]>.
++
++RETURNS
++<<iswctype>> returns non-zero if and only if <[c]> matches the test specified by <[desc]>.
++If <[desc]> is unknown, zero is returned.
++
++PORTABILITY
++<<iswctype>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <wctype.h>
++#include "local.h"
++
++int
++_DEFUN(iswctype,(c, desc), wint_t c _AND wctype_t desc)
++{
++  switch (desc)
++    {
++    case WC_ALNUM:
++      return iswalnum (c);
++    case WC_ALPHA:
++      return iswalpha (c);
++    case WC_BLANK:
++      return iswblank (c);
++    case WC_CNTRL:
++      return iswcntrl (c);
++    case WC_DIGIT:
++      return iswdigit (c);
++    case WC_GRAPH:
++      return iswgraph (c);
++    case WC_LOWER:
++      return iswlower (c);
++    case WC_PRINT:
++      return iswprint (c);
++    case WC_PUNCT:
++      return iswpunct (c);
++    case WC_SPACE:
++      return iswspace (c);
++    case WC_UPPER:
++      return iswupper (c);
++    case WC_XDIGIT:
++      return iswxdigit (c);
++    default:
++      return 0; /* eliminate warning */
++    }
++
++  /* otherwise unknown */
++  return 0;
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswdigit.c b/msys/rt/src/newlib/libc/ctype/iswdigit.c
+new file mode 100644
+index 0000000..8ba5d5f
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswdigit.c
+@@ -0,0 +1,37 @@
++/*
++FUNCTION
++	<<iswdigit>>---decimal digit wide character test
++
++INDEX
++	iswdigit
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswdigit(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswdigit(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswdigit>> is a function which classifies wide-character values that
++are decimal digits.
++
++RETURNS
++<<iswdigit>> returns non-zero if <[c]> is a decimal digit wide character.
++
++PORTABILITY
++<<iswdigit>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <wctype.h>
++
++int
++_DEFUN(iswdigit,(c), wint_t c)
++{
++  return (c >= (wint_t)'0' && c <= (wint_t)'9');
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswgraph.c b/msys/rt/src/newlib/libc/ctype/iswgraph.c
+new file mode 100644
+index 0000000..bb1e519
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswgraph.c
+@@ -0,0 +1,66 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<iswgraph>>---graphic wide character test
++
++INDEX
++	iswgraph
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswgraph(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswgraph(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswgraph>> is a function which classifies wide-character values that
++are graphic.
++
++RETURNS
++<<iswgraph>> returns non-zero if <[c]> is a graphic wide character.
++
++PORTABILITY
++<<iswgraph>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <wctype.h>
++
++int
++_DEFUN(iswgraph,(c),wint_t c)
++{
++  return (iswprint (c) && !iswspace (c));
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswlower.c b/msys/rt/src/newlib/libc/ctype/iswlower.c
+new file mode 100644
+index 0000000..683a9cb
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswlower.c
+@@ -0,0 +1,38 @@
++
++/*
++FUNCTION
++	<<iswlower>>---lowercase wide character test
++
++INDEX
++	iswlower
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswlower(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswlower(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswlower>> is a function which classifies wide-character values that
++have uppercase translations.
++
++RETURNS
++<<iswlower>> returns non-zero if <[c]> is a lowercase wide character.
++
++PORTABILITY
++<<iswlower>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <wctype.h>
++
++int
++_DEFUN(iswlower,(c),wint_t c)
++{
++	return (towupper (c) != c);
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswprint.c b/msys/rt/src/newlib/libc/ctype/iswprint.c
+new file mode 100644
+index 0000000..0ab9559
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswprint.c
+@@ -0,0 +1,496 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<iswprint>>---printable wide character test
++
++INDEX
++	iswprint
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswprint(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswprint(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswprint>> is a function which classifies wide-character values that
++are printable.
++
++RETURNS
++<<iswprint>> returns non-zero if <[c]> is a printable wide character.
++
++PORTABILITY
++<<iswprint>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <newlib.h>
++#include <wctype.h>
++#include <string.h>
++#include <ctype.h>
++#include "local.h"
++
++#ifdef _MB_CAPABLE
++#include "utf8print.h"
++#endif /* _MB_CAPABLE */
++
++int
++_DEFUN(iswprint,(c), wint_t c)
++{
++#ifdef _MB_CAPABLE
++  unsigned const char *table;
++  unsigned char *ptr;
++  unsigned char ctmp;
++  int size;
++  wint_t x;
++  
++  c = _jp2uc (c);
++
++  /* Based on and tested against Unicode 5.2
++     See utf8print.h for a description how to fetch the data. */
++  x = (c >> 8);
++  /* for some large sections, all characters are printuation so handle them here */
++  if ((x >= 0x33 && x <= 0x4c) ||
++      (x >= 0x4e && x <= 0x9e) ||
++      (x >= 0xa0 && x <= 0xa3) ||
++      (x >= 0xac && x <= 0xd6) ||
++      (x >= 0xe0 && x <= 0xf9) ||
++      (x >= 0x120 && x <= 0x122) ||
++      (x >= 0x130 && x <= 0x133) ||
++      (x >= 0x200 && x <= 0x2a5) ||
++      (x >= 0x2a7 && x <= 0x2b6) ||
++      (x >= 0xf00 && x <= 0xffe) ||
++      (x >= 0x1000 && x <= 0x10fe))
++    return 1;
++  
++  switch (x)
++    {
++    case 0x01:
++    case 0x02:
++    case 0x04:
++    case 0x11:
++    case 0x14:
++    case 0x15:
++    case 0x1e:
++    case 0x22:
++    case 0x25:
++    case 0x28:
++    case 0x29:
++    case 0x2a:
++    case 0xa5:
++    case 0xfc:
++    case 0x2f8:
++    case 0x2f9:
++      return 1;
++    case 0x00:
++      table = u0;
++      size = sizeof(u0);
++      break;
++    case 0x03:
++      table = u3;
++      size = sizeof(u3);
++      break;
++    case 0x05:
++      table = u5;
++      size = sizeof(u5);
++      break;
++    case 0x06:
++      table = u6;
++      size = sizeof(u6);
++      break;
++    case 0x07:
++      table = u7;
++      size = sizeof(u7);
++      break;
++    case 0x08:
++      table = u8;
++      size = sizeof(u8);
++      break;
++    case 0x09:
++      table = u9;
++      size = sizeof(u9);
++      break;
++    case 0x0a:
++      table = ua;
++      size = sizeof(ua);
++      break;
++    case 0x0b:
++      table = ub;
++      size = sizeof(ub);
++      break;
++    case 0x0c:
++      table = uc;
++      size = sizeof(uc);
++      break;
++    case 0x0d:
++      table = ud;
++      size = sizeof(ud);
++      break;
++    case 0x0e:
++      table = ue;
++      size = sizeof(ue);
++      break;
++    case 0x0f:
++      table = uf;
++      size = sizeof(uf);
++      break;
++    case 0x10:
++      table = u10;
++      size = sizeof(u10);
++      break;
++    case 0x12:
++      table = u12;
++      size = sizeof(u12);
++      break;
++    case 0x13:
++      table = u13;
++      size = sizeof(u13);
++      break;
++    case 0x16:
++      table = u16;
++      size = sizeof(u16);
++      break;
++    case 0x17:
++      table = u17;
++      size = sizeof(u17);
++      break;
++    case 0x18:
++      table = u18;
++      size = sizeof(u18);
++      break;
++    case 0x19:
++      table = u19;
++      size = sizeof(u19);
++      break;
++    case 0x1a:
++      table = u1a;
++      size = sizeof(u1a);
++      break;
++    case 0x1b:
++      table = u1b;
++      size = sizeof(u1b);
++      break;
++    case 0x1c:
++      table = u1c;
++      size = sizeof(u1c);
++      break;
++    case 0x1d:
++      table = u1d;
++      size = sizeof(u1d);
++      break;
++    case 0x1f:
++      table = u1f;
++      size = sizeof(u1f);
++      break;
++    case 0x20:
++      table = u20;
++      size = sizeof(u20);
++      break;
++    case 0x21:
++      table = u21;
++      size = sizeof(u21);
++      break;
++    case 0x23:
++      table = u23;
++      size = sizeof(u23);
++      break;
++    case 0x24:
++      table = u24;
++      size = sizeof(u24);
++      break;
++    case 0x26:
++      table = u26;
++      size = sizeof(u26);
++      break;
++    case 0x27:
++      table = u27;
++      size = sizeof(u27);
++      break;
++    case 0x2b:
++      table = u2b;
++      size = sizeof(u2b);
++      break;
++    case 0x2c:
++      table = u2c;
++      size = sizeof(u2c);
++      break;
++    case 0x2d:
++      table = u2d;
++      size = sizeof(u2d);
++      break;
++    case 0x2e:
++      table = u2e;
++      size = sizeof(u2e);
++      break;
++    case 0x2f:
++      table = u2f;
++      size = sizeof(u2f);
++      break;
++    case 0x30:
++      table = u30;
++      size = sizeof(u30);
++      break;
++    case 0x31:
++      table = u31;
++      size = sizeof(u31);
++      break;
++    case 0x32:
++      table = u32;
++      size = sizeof(u32);
++      break;
++    case 0x4d:
++      table = u4d;
++      size = sizeof(u4d);
++      break;
++    case 0x9f:
++      table = u9f;
++      size = sizeof(u9f);
++      break;
++    case 0xa4:
++      table = ua4;
++      size = sizeof(ua4);
++      break;
++    case 0xa6:
++      table = ua6;
++      size = sizeof(ua6);
++      break;
++    case 0xa7:
++      table = ua7;
++      size = sizeof(ua7);
++      break;
++    case 0xa8:
++      table = ua8;
++      size = sizeof(ua8);
++      break;
++    case 0xa9:
++      table = ua9;
++      size = sizeof(ua9);
++      break;
++    case 0xaa:
++      table = uaa;
++      size = sizeof(uaa);
++      break;
++    case 0xab:
++      table = uab;
++      size = sizeof(uab);
++      break;
++    case 0xd7:
++      table = ud7;
++      size = sizeof(ud7);
++      break;
++    case 0xfa:
++      table = ufa;
++      size = sizeof(ufa);
++      break;
++    case 0xfb:
++      table = ufb;
++      size = sizeof(ufb);
++      break;
++    case 0xfd:
++      table = ufd;
++      size = sizeof(ufd);
++      break;
++    case 0xfe:
++      table = ufe;
++      size = sizeof(ufe);
++      break;
++    case 0xff:
++      table = uff;
++      size = sizeof(uff);
++      break;
++    case 0x100:
++      table = u100;
++      size = sizeof(u100);
++      break;
++    case 0x101:
++      table = u101;
++      size = sizeof(u101);
++      break;
++    case 0x102:
++      table = u102;
++      size = sizeof(u102);
++      break;
++    case 0x103:
++      table = u103;
++      size = sizeof(u103);
++      break;
++    case 0x104:
++      table = u104;
++      size = sizeof(u104);
++      break;
++    case 0x108:
++      table = u108;
++      size = sizeof(u108);
++      break;
++    case 0x109:
++      table = u109;
++      size = sizeof(u109);
++      break;
++    case 0x10a:
++      table = u10a;
++      size = sizeof(u10a);
++      break;
++    case 0x10b:
++      table = u10b;
++      size = sizeof(u10b);
++      break;
++    case 0x10c:
++      table = u10c;
++      size = sizeof(u10c);
++      break;
++    case 0x10e:
++      table = u10e;
++      size = sizeof(u10e);
++      break;
++    case 0x110:
++      table = u110;
++      size = sizeof(u110);
++      break;
++    case 0x123:
++      table = u123;
++      size = sizeof(u123);
++      break;
++    case 0x124:
++      table = u124;
++      size = sizeof(u124);
++      break;
++    case 0x134:
++      table = u134;
++      size = sizeof(u134);
++      break;
++    case 0x1d0:
++      table = u1d0;
++      size = sizeof(u1d0);
++      break;
++    case 0x1d1:
++      table = u1d1;
++      size = sizeof(u1d1);
++      break;
++    case 0x1d2:
++      table = u1d2;
++      size = sizeof(u1d2);
++      break;
++    case 0x1d3:
++      table = u1d3;
++      size = sizeof(u1d3);
++      break;
++    case 0x1d4:
++      table = u1d4;
++      size = sizeof(u1d4);
++      break;
++    case 0x1d5:
++      table = u1d5;
++      size = sizeof(u1d5);
++      break;
++    case 0x1d6:
++      table = u1d6;
++      size = sizeof(u1d6);
++      break;
++    case 0x1d7:
++      table = u1d7;
++      size = sizeof(u1d7);
++      break;
++    case 0x1f0:
++      table = u1f0;
++      size = sizeof(u1f0);
++      break;
++    case 0x1f1:
++      table = u1f1;
++      size = sizeof(u1f1);
++      break;
++    case 0x1f2:
++      table = u1f2;
++      size = sizeof(u1f2);
++      break;
++    case 0x2a6:
++      table = u2a6;
++      size = sizeof(u2a6);
++      break;
++    case 0x2b7:
++      table = u2b7;
++      size = sizeof(u2b7);
++      break;
++    case 0x2fa:
++      table = u2fa;
++      size = sizeof(u2fa);
++      break;
++    case 0xe00:
++      table = ue00;
++      size = sizeof(ue00);
++      break;
++    case 0xe01:
++      table = ue01;
++      size = sizeof(ue01);
++      break;
++    case 0xfff:
++      table = ufff;
++      size = sizeof(ufff);
++      break;
++    case 0x10ff:
++      table = u10ff;
++      size = sizeof(u10ff);
++      break;
++    default:
++      return 0;
++    }
++  /* we have narrowed down to a section of 256 characters to check */
++  /* now check if c matches the printuation wide-chars within that section */
++  ptr = (unsigned char *)table;
++  ctmp = (unsigned char)c;
++  while (ptr < table + size)
++    {
++      if (ctmp == *ptr)
++	return 1;
++      if (ctmp < *ptr)
++	return 0;
++      /* otherwise c > *ptr */
++      /* look for 0x0 as next element which indicates a range */
++      ++ptr;
++      if (*ptr == 0x0)
++	{
++	  /* we have a range..see if c falls within range */
++	  ++ptr;
++	  if (ctmp <= *ptr)
++	    return 1;
++	  ++ptr;
++	}
++    }
++  /* not in table */
++  return 0;
++#else
++  return (c < (wint_t)0x100 ? isprint (c) : 0);
++#endif /* _MB_CAPABLE */
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswpunct.c b/msys/rt/src/newlib/libc/ctype/iswpunct.c
+new file mode 100644
+index 0000000..e65771a
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswpunct.c
+@@ -0,0 +1,70 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<iswpunct>>---punctuation wide character test
++
++INDEX
++	iswpunct
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswpunct(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswpunct(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswpunct>> is a function which classifies wide-character values that
++are punctuation.
++
++RETURNS
++<<iswpunct>> returns non-zero if <[c]> is a punctuation wide character.
++
++PORTABILITY
++<<iswpunct>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <newlib.h>
++#include <wctype.h>
++#include <string.h>
++#include <ctype.h>
++#include "local.h"
++
++int
++_DEFUN(iswpunct,(c), wint_t c)
++{
++  return (!iswalnum (c) && iswgraph (c));
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswspace.c b/msys/rt/src/newlib/libc/ctype/iswspace.c
+new file mode 100644
+index 0000000..e738cd6
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswspace.c
+@@ -0,0 +1,83 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<iswspace>>---whitespace wide character test
++
++INDEX
++	iswspace
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswspace(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswspace(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswspace>> is a function which classifies wide-character values that
++are categorized as whitespace.
++
++RETURNS
++<<iswspace>> returns non-zero if <[c]> is a whitespace wide character.
++
++PORTABILITY
++<<iswspace>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <newlib.h>
++#include <wctype.h>
++#include <ctype.h>
++#include <string.h>
++#include "local.h"
++
++int
++_DEFUN(iswspace,(c), wint_t c)
++{
++#ifdef _MB_CAPABLE
++  c = _jp2uc (c);
++  /* Based on Unicode 5.2.  Control chars 09-0D, plus all characters
++     from general category "Zs", which are not marked as decomposition
++     type "noBreak". */
++  return ((c >= 0x0009 && c <= 0x000d) || c == 0x0020 ||
++	  c == 0x1680 || c == 0x180e ||
++	  (c >= 0x2000 && c <= 0x2006) ||
++	  (c >= 0x2008 && c <= 0x200a) ||
++	  c == 0x2028 || c == 0x2029 ||
++	  c == 0x205f || c == 0x3000);
++#else
++  return (c < 0x100 ? isspace (c) : 0);
++#endif /* _MB_CAPABLE */
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswupper.c b/msys/rt/src/newlib/libc/ctype/iswupper.c
+new file mode 100644
+index 0000000..424d652
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswupper.c
+@@ -0,0 +1,38 @@
++
++/*
++FUNCTION
++	<<iswupper>>---uppercase wide character test
++
++INDEX
++	iswupper
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswupper(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswupper(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswupper>> is a function which classifies wide-character values that
++have uppercase translations.
++
++RETURNS
++<<iswupper>> returns non-zero if <[c]> is a uppercase wide character.
++
++PORTABILITY
++<<iswupper>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <wctype.h>
++
++int
++_DEFUN(iswupper,(c),wint_t c)
++{
++  return (towlower (c) != c);
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/iswxdigit.c b/msys/rt/src/newlib/libc/ctype/iswxdigit.c
+new file mode 100644
+index 0000000..4cf76fa
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/iswxdigit.c
+@@ -0,0 +1,39 @@
++/*
++FUNCTION
++	<<iswxdigit>>---hexadecimal digit wide character test
++
++INDEX
++	iswxdigit
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	int iswxdigit(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	int iswxdigit(<[c]>)
++	wint_t <[c]>;
++
++DESCRIPTION
++<<iswxdigit>> is a function which classifies wide character values that
++are hexadecimal digits.
++
++RETURNS
++<<iswxdigit>> returns non-zero if <[c]> is a hexadecimal digit wide character.
++
++PORTABILITY
++<<iswxdigit>> is C99.
++
++No supporting OS subroutines are required.
++*/
++#include <_ansi.h>
++#include <wctype.h>
++
++int
++_DEFUN(iswxdigit,(c), wint_t c)
++{
++  return ((c >= (wint_t)'0' && c <= (wint_t)'9') ||
++	  (c >= (wint_t)'a' && c <= (wint_t)'f') ||
++	  (c >= (wint_t)'A' && c <= (wint_t)'F'));
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/jp2uc.c b/msys/rt/src/newlib/libc/ctype/jp2uc.c
+new file mode 100644
+index 0000000..4086613
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/jp2uc.c
+@@ -0,0 +1,166 @@
++/* Routine to translate from Japanese characters to Unicode */
++
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#include <newlib.h>
++
++#ifdef _MB_CAPABLE
++/* Under Cygwin, the incoming wide character is already given in UTF due
++   to the requirements of the underlying OS. */
++#if !defined(__CYGWIN__) && !defined(__MSYS__)
++
++#include <_ansi.h>
++#include <wctype.h>
++#include "local.h"
++#include "jp2uc.h"
++
++/* Japanese encoding types supported */
++#define JP_JIS		1
++#define JP_SJIS		2
++#define JP_EUCJP	3
++
++static wint_t
++_DEFUN (__jp2uc, (c, type), wint_t c _AND int type)
++{
++  int index, adj;
++  unsigned char byte1, byte2;
++  wint_t ret;
++
++  /* we actually use tables of EUCJP to Unicode.  For JIS, we simply
++     note that EUCJP is essentially JIS with the top bits on in each
++     byte and translate to EUCJP.  For SJIS, we do a translation to EUCJP before
++     accessing the tables. */
++  switch (type)
++    {
++    case JP_JIS:
++      byte1 = (c >> 8) + 0x80;
++      byte2 = (c & 0xff) + 0x80;
++      break;
++    case JP_EUCJP:
++      byte1 = (c >> 8);
++      byte2 = (c & 0xff);
++      break;
++    case JP_SJIS:
++      byte1 = c >> 8;
++      byte2 = c & 0xff;
++      if (byte2 <= 0x9e)
++        {
++          adj = 0xa1 - 0x22;
++          byte2 = (byte2 - 31) + 0xa1;
++        }
++      else
++        {
++          adj = 0xa1 - 0x21;
++          byte2 = (byte2 - 126) + 0xa1;
++        }
++      if (byte1 <= 0x9f)
++        byte1 = ((byte1 - 112) << 1) + adj;
++      else
++        byte1 = ((byte1 - 176) << 1) + adj;
++      break;
++    default:
++      return WEOF;
++    }
++
++  /* find conversion in jp2uc arrays */
++
++  /* handle larger ranges first */
++  if (byte1 >= 0xb0 && byte1 <= 0xcf && c <= 0xcfd3)
++    {
++      index = (byte1 - 0xb0) * 0xfe + (byte2 - 0xa1);
++      return b02cf[index];
++    }
++  else if (byte1 >= 0xd0 && byte1 <= 0xf4 && c <= 0xf4a6)
++    {
++      index = (byte1 - 0xd0) * 0xfe + (byte2 - 0xa1);
++      return d02f4[index];
++    }
++
++  /* handle smaller ranges here */    
++  switch (byte1)
++    {
++    case 0xA1:
++      return (wint_t)a1[byte2 - 0xa1];
++    case 0xA2:
++      ret = a2[byte2 - 0xa1];
++      if (ret != 0)
++	return (wint_t)ret;
++      break;
++    case 0xA3:
++      if (a3[byte2 - 0xa1])
++	return (wint_t)(0xff00 + (byte2 - 0xa0));
++      break;
++    case 0xA4:
++      if (byte2 <= 0xf3)
++	return (wint_t)(0x3000 + (byte2 - 0x60));
++      break;
++    case 0xA5:
++      if (byte2 <= 0xf6)
++	return (wint_t)(0x3000 + byte2);
++      break;
++    case 0xA6:
++      ret = 0;
++      if (byte2 <= 0xd8)
++	ret = (wint_t)a6[byte2 - 0xa1];
++      if (ret != 0)
++	return ret;
++      break;
++    case 0xA7:
++      ret = 0;
++      if (byte2 <= 0xf1)
++	ret = (wint_t)a7[byte2 - 0xa1];
++      if (ret != 0)
++	return ret;
++      break;
++    case 0xA8:
++      if (byte2 <= 0xc0)
++	return (wint_t)a8[byte2 - 0xa1];
++      break;
++    default:
++      return WEOF;
++    }
++
++  return WEOF; 
++}
++
++wint_t
++_DEFUN (_jp2uc, (c), wint_t c)
++{
++  if (!strcmp (__locale_charset (), "JIS"))
++    c = __jp2uc (c, JP_JIS);
++  else if (!strcmp (__locale_charset (), "SJIS"))
++    c = __jp2uc (c, JP_SJIS);
++  else if (!strcmp (__locale_charset (), "EUCJP"))
++    c = __jp2uc (c, JP_EUCJP);
++  return c;
++}
++
++#endif /* !__CYGWIN__ */
++#endif /* _MB_CAPABLE */
+diff --git a/msys/rt/src/newlib/libc/ctype/jp2uc.h b/msys/rt/src/newlib/libc/ctype/jp2uc.h
+new file mode 100644
+index 0000000..04eb67d
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/jp2uc.h
+@@ -0,0 +1,6849 @@
++/* based on eucjp-208A.txt */
++
++/* a1 is contiguous from a1a1 to a1fe */
++static unsigned short a1[] = {
++  0x3000,
++  0x3001,
++  0x3002,
++  0xFF0C,
++  0xFF0E,
++  0x30FB,
++  0xFF1A,
++  0xFF1B,
++  0xFF1F,
++  0xFF01,
++  0x309B,
++  0x309C,
++  0x00B4,
++  0xFF40,
++  0x00A8,
++  0xFF3E,
++  0x203E,
++  0xFF3F,
++  0x30FD,
++  0x30FE,
++  0x309D,
++  0x309E,
++  0x3003,
++  0x4EDD,
++  0x3005,
++  0x3006,
++  0x3007,
++  0x30FC,
++  0x2014,
++  0x2010,
++  0xFF0F,
++  0xFF3C,
++  0x301C,
++  0x2016,
++  0xFF5C,
++  0x2026,
++  0x2025,
++  0x2018,
++  0x2019,
++  0x201C,
++  0x201D,
++  0xFF08,
++  0xFF09,
++  0x3014,
++  0x3015,
++  0xFF3B,
++  0xFF3D,
++  0xFF5B,
++  0xFF5D,
++  0x3008,
++  0x3009,
++  0x300A,
++  0x300B,
++  0x300C,
++  0x300D,
++  0x300E,
++  0x300F,
++  0x3010,
++  0x3011,
++  0xFF0B,
++  0x2212,
++  0x00B1,
++  0x00D7,
++  0x00F7,
++  0xFF1D,
++  0x2260,
++  0xFF1C,
++  0xFF1E,
++  0x2266,
++  0x2267,
++  0x221E,
++  0x2234,
++  0x2642,
++  0x2640,
++  0x00B0,
++  0x2032,
++  0x2033,
++  0x2103,
++  0x00A5,
++  0xFF04,
++  0x00A2,
++  0x00A3,
++  0xFF05,
++  0xFF03,
++  0xFF06,
++  0xFF0A,
++  0xFF20,
++  0x00A7,
++  0x2606,
++  0x2605,
++  0x25CB,
++  0x25CF,
++  0x25CE,
++  0x25C7
++};
++
++/* a2 has a number of holes between a2a1 and a2fe which we fill with 0x0000 */
++static unsigned short a2[] = {
++  0x25C6,
++  0x25A1,
++  0x25A0,
++  0x25B3,
++  0x25B2,
++  0x25BD,
++  0x25BC,
++  0x203B,
++  0x3012,
++  0x2192,
++  0x2190,
++  0x2191,
++  0x2193,
++  0x3013,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x2208,
++  0x220B,
++  0x2286,
++  0x2287,
++  0x2282,
++  0x2283,
++  0x222A,
++  0x2229,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x2227,
++  0x2228,
++  0x00AC,
++  0x21D2,
++  0x21D4,
++  0x2200,
++  0x2203,
++  0x2229,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x2220,
++  0x22A5,
++  0x2312,
++  0x2202,
++  0x2207,
++  0x2261,
++  0x2252,
++  0x226A,
++  0x226B,
++  0x221A,
++  0x223D,
++  0x221D,
++  0x2235,
++  0x222B,
++  0x222C,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x212B,
++  0x2030,
++  0x266F,
++  0x266D,
++  0x266A,
++  0x2020,
++  0x2021,
++  0x00B6,
++  0x222C,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x25EF
++};
++
++
++/* a3a1 to a3fe is mostly contiguous.  Conversion output values are
++   of the form 0xFFxx where xx is (yy - 0xA0) where the input is 0xA3yy */
++static unsigned char a3[] = {
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  0,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1,
++  1
++};
++
++/* a4 is contiguous from a4a1 to a4f3 */
++/* transform = 0x30xx where xx = last byte - 0x60 */
++
++/* a5 is contiguous from a5a1 to a5f6 */
++/* transform = 0x30xx where xx = last byte */
++
++/* a6 is mostly contiguous from a6a1 to a6d8 */
++static unsigned short a6[] = {
++  0x0391,
++  0x0392,
++  0x0393,
++  0x0394,
++  0x0395,
++  0x0396,
++  0x0397,
++  0x0398,
++  0x0399,
++  0x039A,
++  0x039B,
++  0x039C,
++  0x039D,
++  0x039E,
++  0x039F,
++  0x03A0,
++  0x03A1,
++  0x03A3,
++  0x03A4,
++  0x03A5,
++  0x03A6,
++  0x03A7,
++  0x03A8,
++  0x03A9,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x03B1,
++  0x03B2,
++  0x03B3,
++  0x03B4,
++  0x03B5,
++  0x03B6,
++  0x03B7,
++  0x03B8,
++  0x03B9,
++  0x03BA,
++  0x03BB,
++  0x03BC,
++  0x03BD,
++  0x03BE,
++  0x03BF,
++  0x03C0,
++  0x03C1,
++  0x03C3,
++  0x03C4,
++  0x03C5,
++  0x03C6,
++  0x03C7,
++  0x03C8,
++  0x03C9
++};
++
++/* a7 is mostly contiguous from a7a1 to a7f1 */
++static unsigned short a7[] = {
++  0x0410,
++  0x0411,
++  0x0412,
++  0x0413,
++  0x0414,
++  0x0415,
++  0x0401,
++  0x0416,
++  0x0417,
++  0x0418,
++  0x0419,
++  0x041A,
++  0x041B,
++  0x041C,
++  0x041D,
++  0x041E,
++  0x041F,
++  0x0420,
++  0x0421,
++  0x0422,
++  0x0423,
++  0x0424,
++  0x0425,
++  0x0426,
++  0x0427,
++  0x0428,
++  0x0429,
++  0x042A,
++  0x042B,
++  0x042C,
++  0x042D,
++  0x042E,
++  0x042F,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0000,
++  0x0430,
++  0x0431,
++  0x0432,
++  0x0433,
++  0x0434,
++  0x0435,
++  0x0451,
++  0x0436,
++  0x0437,
++  0x0438,
++  0x0439,
++  0x043A,
++  0x043B,
++  0x043C,
++  0x043D,
++  0x043E,
++  0x043F,
++  0x0440,
++  0x0441,
++  0x0442,
++  0x0443,
++  0x0444,
++  0x0445,
++  0x0446,
++  0x0447,
++  0x0448,
++  0x0449,
++  0x044A,
++  0x044B,
++  0x044C,
++  0x044D,
++  0x044E,
++  0x044F
++};
++
++/* a8 is contiguous from a8a1 to a8c0 */
++static unsigned short a8[] = {
++  0x2500,
++  0x2502,
++  0x250C,
++  0x2510,
++  0x2518,
++  0x2514,
++  0x251C,
++  0x252C,
++  0x2524,
++  0x2534,
++  0x253C,
++  0x2501,
++  0x2503,
++  0x250F,
++  0x2513,
++  0x251B,
++  0x2517,
++  0x2523,
++  0x2533,
++  0x252B,
++  0x253B,
++  0x254B,
++  0x2520,
++  0x252F,
++  0x2528,
++  0x2537,
++  0x253F,
++  0x251D,
++  0x2530,
++  0x2525,
++  0x2538,
++  0x2542
++};
++
++/* no conversion a9 to af */
++
++/* b0a1 to cfd3 is contiguous except for illegal sequences with 0xfe */
++static unsigned short b02cf[] = {
++  0x4E9C,
++  0x5516,
++  0x5A03,
++  0x963F,
++  0x54C0,
++  0x611B,
++  0x6328,
++  0x59F6,
++  0x9022,
++  0x8475,
++  0x831C,
++  0x7A50,
++  0x60AA,
++  0x63E1,
++  0x6E25,
++  0x65ED,
++  0x8466,
++  0x82A6,
++  0x9BF5,
++  0x6893,
++  0x5727,
++  0x65A1,
++  0x6271,
++  0x5B9B,
++  0x59D0,
++  0x867B,
++  0x98F4,
++  0x7D62,
++  0x7DBE,
++  0x9B8E,
++  0x6216,
++  0x7C9F,
++  0x88B7,
++  0x5B89,
++  0x5EB5,
++  0x6309,
++  0x6697,
++  0x6848,
++  0x95C7,
++  0x978D,
++  0x674F,
++  0x4EE5,
++  0x4F0A,
++  0x4F4D,
++  0x4F9D,
++  0x5049,
++  0x56F2,
++  0x5937,
++  0x59D4,
++  0x5A01,
++  0x5C09,
++  0x60DF,
++  0x610F,
++  0x6170,
++  0x6613,
++  0x6905,
++  0x70BA,
++  0x754F,
++  0x7570,
++  0x79FB,
++  0x7DAD,
++  0x7DEF,
++  0x80C3,
++  0x840E,
++  0x8863,
++  0x8B02,
++  0x9055,
++  0x907A,
++  0x533B,
++  0x4E95,
++  0x4EA5,
++  0x57DF,
++  0x80B2,
++  0x90C1,
++  0x78EF,
++  0x4E00,
++  0x58F1,
++  0x6EA2,
++  0x9038,
++  0x7A32,
++  0x8328,
++  0x828B,
++  0x9C2F,
++  0x5141,
++  0x5370,
++  0x54BD,
++  0x54E1,
++  0x56E0,
++  0x59FB,
++  0x5F15,
++  0x98F2,
++  0x6DEB,
++  0x80E4,
++  0x852D,
++  0x9662,
++  0x9670,
++  0x96A0,
++  0x97FB,
++  0x540B,
++  0x53F3,
++  0x5B87,
++  0x70CF,
++  0x7FBD,
++  0x8FC2,
++  0x96E8,
++  0x536F,
++  0x9D5C,
++  0x7ABA,
++  0x4E11,
++  0x7893,
++  0x81FC,
++  0x6E26,
++  0x5618,
++  0x5504,
++  0x6B1D,
++  0x851A,
++  0x9C3B,
++  0x59E5,
++  0x53A9,
++  0x6D66,
++  0x74DC,
++  0x958F,
++  0x5642,
++  0x4E91,
++  0x904B,
++  0x96F2,
++  0x834F,
++  0x990C,
++  0x53E1,
++  0x55B6,
++  0x5B30,
++  0x5F71,
++  0x6620,
++  0x66F3,
++  0x6804,
++  0x6C38,
++  0x6CF3,
++  0x6D29,
++  0x745B,
++  0x76C8,
++  0x7A4E,
++  0x9834,
++  0x82F1,
++  0x885B,
++  0x8A60,
++  0x92ED,
++  0x6DB2,
++  0x75AB,
++  0x76CA,
++  0x99C5,
++  0x60A6,
++  0x8B01,
++  0x8D8A,
++  0x95B2,
++  0x698E,
++  0x53AD,
++  0x5186,
++  0x5712,
++  0x5830,
++  0x5944,
++  0x5BB4,
++  0x5EF6,
++  0x6028,
++  0x63A9,
++  0x63F4,
++  0x6CBF,
++  0x6F14,
++  0x708E,
++  0x7114,
++  0x7159,
++  0x71D5,
++  0x733F,
++  0x7E01,
++  0x8276,
++  0x82D1,
++  0x8597,
++  0x9060,
++  0x925B,
++  0x9D1B,
++  0x5869,
++  0x65BC,
++  0x6C5A,
++  0x7525,
++  0x51F9,
++  0x592E,
++  0x5965,
++  0x5F80,
++  0x5FDC,
++  0x62BC,
++  0x65FA,
++  0x6A2A,
++  0x6B27,
++  0x6BB4,
++  0x738B,
++  0x7FC1,
++  0x8956,
++  0x9D2C,
++  0x9D0E,
++  0x9EC4,
++  0x5CA1,
++  0x6C96,
++  0x837B,
++  0x5104,
++  0x5C4B,
++  0x61B6,
++  0x81C6,
++  0x6876,
++  0x7261,
++  0x4E59,
++  0x4FFA,
++  0x5378,
++  0x6069,
++  0x6E29,
++  0x7A4F,
++  0x97F3,
++  0x4E0B,
++  0x5316,
++  0x4EEE,
++  0x4F55,
++  0x4F3D,
++  0x4FA1,
++  0x4F73,
++  0x52A0,
++  0x53EF,
++  0x5609,
++  0x590F,
++  0x5AC1,
++  0x5BB6,
++  0x5BE1,
++  0x79D1,
++  0x6687,
++  0x679C,
++  0x67B6,
++  0x6B4C,
++  0x6CB3,
++  0x706B,
++  0x73C2,
++  0x798D,
++  0x79BE,
++  0x7A3C,
++  0x7B87,
++  0x82B1,
++  0x82DB,
++  0x8304,
++  0x8377,
++  0x83EF,
++  0x83D3,
++  0x8766,
++  0x8AB2,
++  0x5629,
++  0x8CA8,
++  0x8FE6,
++  0x904E,
++  0x971E,
++  0x868A,
++  0x4FC4,
++  0x5CE8,
++  0x6211,
++  0x7259,
++  0x753B,
++  0x81E5,
++  0x82BD,
++  0x86FE,
++  0x8CC0,
++  0x96C5,
++  0x9913,
++  0x99D5,
++  0x4ECB,
++  0x4F1A,
++  0x89E3,
++  0x56DE,
++  0x584A,
++  0x58CA,
++  0x5EFB,
++  0x5FEB,
++  0x602A,
++  0x6094,
++  0x6062,
++  0x61D0,
++  0x6212,
++  0x62D0,
++  0x6539,
++  0x9B41,
++  0x6666,
++  0x68B0,
++  0x6D77,
++  0x7070,
++  0x754C,
++  0x7686,
++  0x7D75,
++  0x82A5,
++  0x87F9,
++  0x958B,
++  0x968E,
++  0x8C9D,
++  0x51F1,
++  0x52BE,
++  0x5916,
++  0x54B3,
++  0x5BB3,
++  0x5D16,
++  0x6168,
++  0x6982,
++  0x6DAF,
++  0x788D,
++  0x84CB,
++  0x8857,
++  0x8A72,
++  0x93A7,
++  0x9AB8,
++  0x6D6C,
++  0x99A8,
++  0x86D9,
++  0x57A3,
++  0x67FF,
++  0x86CE,
++  0x920E,
++  0x5283,
++  0x5687,
++  0x5404,
++  0x5ED3,
++  0x62E1,
++  0x64B9,
++  0x683C,
++  0x6838,
++  0x6BBB,
++  0x7372,
++  0x78BA,
++  0x7A6B,
++  0x899A,
++  0x89D2,
++  0x8D6B,
++  0x8F03,
++  0x90ED,
++  0x95A3,
++  0x9694,
++  0x9769,
++  0x5B66,
++  0x5CB3,
++  0x697D,
++  0x984D,
++  0x984E,
++  0x639B,
++  0x7B20,
++  0x6A2B,
++  0x6A7F,
++  0x68B6,
++  0x9C0D,
++  0x6F5F,
++  0x5272,
++  0x559D,
++  0x6070,
++  0x62EC,
++  0x6D3B,
++  0x6E07,
++  0x6ED1,
++  0x845B,
++  0x8910,
++  0x8F44,
++  0x4E14,
++  0x9C39,
++  0x53F6,
++  0x691B,
++  0x6A3A,
++  0x9784,
++  0x682A,
++  0x515C,
++  0x7AC3,
++  0x84B2,
++  0x91DC,
++  0x938C,
++  0x565B,
++  0x9D28,
++  0x6822,
++  0x8305,
++  0x8431,
++  0x7CA5,
++  0x5208,
++  0x82C5,
++  0x74E6,
++  0x4E7E,
++  0x4F83,
++  0x51A0,
++  0x5BD2,
++  0x520A,
++  0x52D8,
++  0x52E7,
++  0x5DFB,
++  0x559A,
++  0x582A,
++  0x59E6,
++  0x5B8C,
++  0x5B98,
++  0x5BDB,
++  0x5E72,
++  0x5E79,
++  0x60A3,
++  0x611F,
++  0x6163,
++  0x61BE,
++  0x63DB,
++  0x6562,
++  0x67D1,
++  0x6853,
++  0x68FA,
++  0x6B3E,
++  0x6B53,
++  0x6C57,
++  0x6F22,
++  0x6F97,
++  0x6F45,
++  0x74B0,
++  0x7518,
++  0x76E3,
++  0x770B,
++  0x7AFF,
++  0x7BA1,
++  0x7C21,
++  0x7DE9,
++  0x7F36,
++  0x7FF0,
++  0x809D,
++  0x8266,
++  0x839E,
++  0x89B3,
++  0x8ACC,
++  0x8CAB,
++  0x9084,
++  0x9451,
++  0x9593,
++  0x9591,
++  0x95A2,
++  0x9665,
++  0x97D3,
++  0x9928,
++  0x8218,
++  0x4E38,
++  0x542B,
++  0x5CB8,
++  0x5DCC,
++  0x73A9,
++  0x764C,
++  0x773C,
++  0x5CA9,
++  0x7FEB,
++  0x8D0B,
++  0x96C1,
++  0x9811,
++  0x9854,
++  0x9858,
++  0x4F01,
++  0x4F0E,
++  0x5371,
++  0x559C,
++  0x5668,
++  0x57FA,
++  0x5947,
++  0x5B09,
++  0x5BC4,
++  0x5C90,
++  0x5E0C,
++  0x5E7E,
++  0x5FCC,
++  0x63EE,
++  0x673A,
++  0x65D7,
++  0x65E2,
++  0x671F,
++  0x68CB,
++  0x68C4,
++  0x6A5F,
++  0x5E30,
++  0x6BC5,
++  0x6C17,
++  0x6C7D,
++  0x757F,
++  0x7948,
++  0x5B63,
++  0x7A00,
++  0x7D00,
++  0x5FBD,
++  0x898F,
++  0x8A18,
++  0x8CB4,
++  0x8D77,
++  0x8ECC,
++  0x8F1D,
++  0x98E2,
++  0x9A0E,
++  0x9B3C,
++  0x4E80,
++  0x507D,
++  0x5100,
++  0x5993,
++  0x5B9C,
++  0x622F,
++  0x6280,
++  0x64EC,
++  0x6B3A,
++  0x72A0,
++  0x7591,
++  0x7947,
++  0x7FA9,
++  0x87FB,
++  0x8ABC,
++  0x8B70,
++  0x63AC,
++  0x83CA,
++  0x97A0,
++  0x5409,
++  0x5403,
++  0x55AB,
++  0x6854,
++  0x6A58,
++  0x8A70,
++  0x7827,
++  0x6775,
++  0x9ECD,
++  0x5374,
++  0x5BA2,
++  0x811A,
++  0x8650,
++  0x9006,
++  0x4E18,
++  0x4E45,
++  0x4EC7,
++  0x4F11,
++  0x53CA,
++  0x5438,
++  0x5BAE,
++  0x5F13,
++  0x6025,
++  0x6551,
++  0x673D,
++  0x6C42,
++  0x6C72,
++  0x6CE3,
++  0x7078,
++  0x7403,
++  0x7A76,
++  0x7AAE,
++  0x7B08,
++  0x7D1A,
++  0x7CFE,
++  0x7D66,
++  0x65E7,
++  0x725B,
++  0x53BB,
++  0x5C45,
++  0x5DE8,
++  0x62D2,
++  0x62E0,
++  0x6319,
++  0x6E20,
++  0x865A,
++  0x8A31,
++  0x8DDD,
++  0x92F8,
++  0x6F01,
++  0x79A6,
++  0x9B5A,
++  0x4EA8,
++  0x4EAB,
++  0x4EAC,
++  0x4F9B,
++  0x4FA0,
++  0x50D1,
++  0x5147,
++  0x7AF6,
++  0x5171,
++  0x51F6,
++  0x5354,
++  0x5321,
++  0x537F,
++  0x53EB,
++  0x55AC,
++  0x5883,
++  0x5CE1,
++  0x5F37,
++  0x5F4A,
++  0x602F,
++  0x6050,
++  0x606D,
++  0x631F,
++  0x6559,
++  0x6A4B,
++  0x6CC1,
++  0x72C2,
++  0x72ED,
++  0x77EF,
++  0x80F8,
++  0x8105,
++  0x8208,
++  0x854E,
++  0x90F7,
++  0x93E1,
++  0x97FF,
++  0x9957,
++  0x9A5A,
++  0x4EF0,
++  0x51DD,
++  0x5C2D,
++  0x6681,
++  0x696D,
++  0x5C40,
++  0x66F2,
++  0x6975,
++  0x7389,
++  0x6850,
++  0x7C81,
++  0x50C5,
++  0x52E4,
++  0x5747,
++  0x5DFE,
++  0x9326,
++  0x65A4,
++  0x6B23,
++  0x6B3D,
++  0x7434,
++  0x7981,
++  0x79BD,
++  0x7B4B,
++  0x7DCA,
++  0x82B9,
++  0x83CC,
++  0x887F,
++  0x895F,
++  0x8B39,
++  0x8FD1,
++  0x91D1,
++  0x541F,
++  0x9280,
++  0x4E5D,
++  0x5036,
++  0x53E5,
++  0x533A,
++  0x72D7,
++  0x7396,
++  0x77E9,
++  0x82E6,
++  0x8EAF,
++  0x99C6,
++  0x99C8,
++  0x99D2,
++  0x5177,
++  0x611A,
++  0x865E,
++  0x55B0,
++  0x7A7A,
++  0x5076,
++  0x5BD3,
++  0x9047,
++  0x9685,
++  0x4E32,
++  0x6ADB,
++  0x91E7,
++  0x5C51,
++  0x5C48,
++  0x6398,
++  0x7A9F,
++  0x6C93,
++  0x9774,
++  0x8F61,
++  0x7AAA,
++  0x718A,
++  0x9688,
++  0x7C82,
++  0x6817,
++  0x7E70,
++  0x6851,
++  0x936C,
++  0x52F2,
++  0x541B,
++  0x85AB,
++  0x8A13,
++  0x7FA4,
++  0x8ECD,
++  0x90E1,
++  0x5366,
++  0x8888,
++  0x7941,
++  0x4FC2,
++  0x50BE,
++  0x5211,
++  0x5144,
++  0x5553,
++  0x572D,
++  0x73EA,
++  0x578B,
++  0x5951,
++  0x5F62,
++  0x5F84,
++  0x6075,
++  0x6176,
++  0x6167,
++  0x61A9,
++  0x63B2,
++  0x643A,
++  0x656C,
++  0x666F,
++  0x6842,
++  0x6E13,
++  0x7566,
++  0x7A3D,
++  0x7CFB,
++  0x7D4C,
++  0x7D99,
++  0x7E4B,
++  0x7F6B,
++  0x830E,
++  0x834A,
++  0x86CD,
++  0x8A08,
++  0x8A63,
++  0x8B66,
++  0x8EFD,
++  0x981A,
++  0x9D8F,
++  0x82B8,
++  0x8FCE,
++  0x9BE8,
++  0x5287,
++  0x621F,
++  0x6483,
++  0x6FC0,
++  0x9699,
++  0x6841,
++  0x5091,
++  0x6B20,
++  0x6C7A,
++  0x6F54,
++  0x7A74,
++  0x7D50,
++  0x8840,
++  0x8A23,
++  0x6708,
++  0x4EF6,
++  0x5039,
++  0x5026,
++  0x5065,
++  0x517C,
++  0x5238,
++  0x5263,
++  0x55A7,
++  0x570F,
++  0x5805,
++  0x5ACC,
++  0x5EFA,
++  0x61B2,
++  0x61F8,
++  0x62F3,
++  0x6372,
++  0x691C,
++  0x6A29,
++  0x727D,
++  0x72AC,
++  0x732E,
++  0x7814,
++  0x786F,
++  0x7D79,
++  0x770C,
++  0x80A9,
++  0x898B,
++  0x8B19,
++  0x8CE2,
++  0x8ED2,
++  0x9063,
++  0x9375,
++  0x967A,
++  0x9855,
++  0x9A13,
++  0x9E78,
++  0x5143,
++  0x539F,
++  0x53B3,
++  0x5E7B,
++  0x5F26,
++  0x6E1B,
++  0x6E90,
++  0x7384,
++  0x73FE,
++  0x7D43,
++  0x8237,
++  0x8A00,
++  0x8AFA,
++  0x9650,
++  0x4E4E,
++  0x500B,
++  0x53E4,
++  0x547C,
++  0x56FA,
++  0x59D1,
++  0x5B64,
++  0x5DF1,
++  0x5EAB,
++  0x5F27,
++  0x6238,
++  0x6545,
++  0x67AF,
++  0x6E56,
++  0x72D0,
++  0x7CCA,
++  0x88B4,
++  0x80A1,
++  0x80E1,
++  0x83F0,
++  0x864E,
++  0x8A87,
++  0x8DE8,
++  0x9237,
++  0x96C7,
++  0x9867,
++  0x9F13,
++  0x4E94,
++  0x4E92,
++  0x4F0D,
++  0x5348,
++  0x5449,
++  0x543E,
++  0x5A2F,
++  0x5F8C,
++  0x5FA1,
++  0x609F,
++  0x68A7,
++  0x6A8E,
++  0x745A,
++  0x7881,
++  0x8A9E,
++  0x8AA4,
++  0x8B77,
++  0x9190,
++  0x4E5E,
++  0x9BC9,
++  0x4EA4,
++  0x4F7C,
++  0x4FAF,
++  0x5019,
++  0x5016,
++  0x5149,
++  0x516C,
++  0x529F,
++  0x52B9,
++  0x52FE,
++  0x539A,
++  0x53E3,
++  0x5411,
++  0x540E,
++  0x5589,
++  0x5751,
++  0x57A2,
++  0x597D,
++  0x5B54,
++  0x5B5D,
++  0x5B8F,
++  0x5DE5,
++  0x5DE7,
++  0x5DF7,
++  0x5E78,
++  0x5E83,
++  0x5E9A,
++  0x5EB7,
++  0x5F18,
++  0x6052,
++  0x614C,
++  0x6297,
++  0x62D8,
++  0x63A7,
++  0x653B,
++  0x6602,
++  0x6643,
++  0x66F4,
++  0x676D,
++  0x6821,
++  0x6897,
++  0x69CB,
++  0x6C5F,
++  0x6D2A,
++  0x6D69,
++  0x6E2F,
++  0x6E9D,
++  0x7532,
++  0x7687,
++  0x786C,
++  0x7A3F,
++  0x7CE0,
++  0x7D05,
++  0x7D18,
++  0x7D5E,
++  0x7DB1,
++  0x8015,
++  0x8003,
++  0x80AF,
++  0x80B1,
++  0x8154,
++  0x818F,
++  0x822A,
++  0x8352,
++  0x884C,
++  0x8861,
++  0x8B1B,
++  0x8CA2,
++  0x8CFC,
++  0x90CA,
++  0x9175,
++  0x9271,
++  0x783F,
++  0x92FC,
++  0x95A4,
++  0x964D,
++  0x9805,
++  0x9999,
++  0x9AD8,
++  0x9D3B,
++  0x525B,
++  0x52AB,
++  0x53F7,
++  0x5408,
++  0x58D5,
++  0x62F7,
++  0x6FE0,
++  0x8C6A,
++  0x8F5F,
++  0x9EB9,
++  0x514B,
++  0x523B,
++  0x544A,
++  0x56FD,
++  0x7A40,
++  0x9177,
++  0x9D60,
++  0x9ED2,
++  0x7344,
++  0x6F09,
++  0x8170,
++  0x7511,
++  0x5FFD,
++  0x60DA,
++  0x9AA8,
++  0x72DB,
++  0x8FBC,
++  0x6B64,
++  0x9803,
++  0x4ECA,
++  0x56F0,
++  0x5764,
++  0x58BE,
++  0x5A5A,
++  0x6068,
++  0x61C7,
++  0x660F,
++  0x6606,
++  0x6839,
++  0x68B1,
++  0x6DF7,
++  0x75D5,
++  0x7D3A,
++  0x826E,
++  0x9B42,
++  0x4E9B,
++  0x4F50,
++  0x53C9,
++  0x5506,
++  0x5D6F,
++  0x5DE6,
++  0x5DEE,
++  0x67FB,
++  0x6C99,
++  0x7473,
++  0x7802,
++  0x8A50,
++  0x9396,
++  0x88DF,
++  0x5750,
++  0x5EA7,
++  0x632B,
++  0x50B5,
++  0x50AC,
++  0x518D,
++  0x6700,
++  0x54C9,
++  0x585E,
++  0x59BB,
++  0x5BB0,
++  0x5F69,
++  0x624D,
++  0x63A1,
++  0x683D,
++  0x6B73,
++  0x6E08,
++  0x707D,
++  0x91C7,
++  0x7280,
++  0x7815,
++  0x7826,
++  0x796D,
++  0x658E,
++  0x7D30,
++  0x83DC,
++  0x88C1,
++  0x8F09,
++  0x969B,
++  0x5264,
++  0x5728,
++  0x6750,
++  0x7F6A,
++  0x8CA1,
++  0x51B4,
++  0x5742,
++  0x962A,
++  0x583A,
++  0x698A,
++  0x80B4,
++  0x54B2,
++  0x5D0E,
++  0x57FC,
++  0x7895,
++  0x9DFA,
++  0x4F5C,
++  0x524A,
++  0x548B,
++  0x643E,
++  0x6628,
++  0x6714,
++  0x67F5,
++  0x7A84,
++  0x7B56,
++  0x7D22,
++  0x932F,
++  0x685C,
++  0x9BAD,
++  0x7B39,
++  0x5319,
++  0x518A,
++  0x5237,
++  0x5BDF,
++  0x62F6,
++  0x64AE,
++  0x64E6,
++  0x672D,
++  0x6BBA,
++  0x85A9,
++  0x96D1,
++  0x7690,
++  0x9BD6,
++  0x634C,
++  0x9306,
++  0x9BAB,
++  0x76BF,
++  0x6652,
++  0x4E09,
++  0x5098,
++  0x53C2,
++  0x5C71,
++  0x60E8,
++  0x6492,
++  0x6563,
++  0x685F,
++  0x71E6,
++  0x73CA,
++  0x7523,
++  0x7B97,
++  0x7E82,
++  0x8695,
++  0x8B83,
++  0x8CDB,
++  0x9178,
++  0x9910,
++  0x65AC,
++  0x66AB,
++  0x6B8B,
++  0x4ED5,
++  0x4ED4,
++  0x4F3A,
++  0x4F7F,
++  0x523A,
++  0x53F8,
++  0x53F2,
++  0x55E3,
++  0x56DB,
++  0x58EB,
++  0x59CB,
++  0x59C9,
++  0x59FF,
++  0x5B50,
++  0x5C4D,
++  0x5E02,
++  0x5E2B,
++  0x5FD7,
++  0x601D,
++  0x6307,
++  0x652F,
++  0x5B5C,
++  0x65AF,
++  0x65BD,
++  0x65E8,
++  0x679D,
++  0x6B62,
++  0x6B7B,
++  0x6C0F,
++  0x7345,
++  0x7949,
++  0x79C1,
++  0x7CF8,
++  0x7D19,
++  0x7D2B,
++  0x80A2,
++  0x8102,
++  0x81F3,
++  0x8996,
++  0x8A5E,
++  0x8A69,
++  0x8A66,
++  0x8A8C,
++  0x8AEE,
++  0x8CC7,
++  0x8CDC,
++  0x96CC,
++  0x98FC,
++  0x6B6F,
++  0x4E8B,
++  0x4F3C,
++  0x4F8D,
++  0x5150,
++  0x5B57,
++  0x5BFA,
++  0x6148,
++  0x6301,
++  0x6642,
++  0x6B21,
++  0x6ECB,
++  0x6CBB,
++  0x723E,
++  0x74BD,
++  0x75D4,
++  0x78C1,
++  0x793A,
++  0x800C,
++  0x8033,
++  0x81EA,
++  0x8494,
++  0x8F9E,
++  0x6C50,
++  0x9E7F,
++  0x5F0F,
++  0x8B58,
++  0x9D2B,
++  0x7AFA,
++  0x8EF8,
++  0x5B8D,
++  0x96EB,
++  0x4E03,
++  0x53F1,
++  0x57F7,
++  0x5931,
++  0x5AC9,
++  0x5BA4,
++  0x6089,
++  0x6E7F,
++  0x6F06,
++  0x75BE,
++  0x8CEA,
++  0x5B9F,
++  0x8500,
++  0x7BE0,
++  0x5072,
++  0x67F4,
++  0x829D,
++  0x5C61,
++  0x854A,
++  0x7E1E,
++  0x820E,
++  0x5199,
++  0x5C04,
++  0x6368,
++  0x8D66,
++  0x659C,
++  0x716E,
++  0x793E,
++  0x7D17,
++  0x8005,
++  0x8B1D,
++  0x8ECA,
++  0x906E,
++  0x86C7,
++  0x90AA,
++  0x501F,
++  0x52FA,
++  0x5C3A,
++  0x6753,
++  0x707C,
++  0x7235,
++  0x914C,
++  0x91C8,
++  0x932B,
++  0x82E5,
++  0x5BC2,
++  0x5F31,
++  0x60F9,
++  0x4E3B,
++  0x53D6,
++  0x5B88,
++  0x624B,
++  0x6731,
++  0x6B8A,
++  0x72E9,
++  0x73E0,
++  0x7A2E,
++  0x816B,
++  0x8DA3,
++  0x9152,
++  0x9996,
++  0x5112,
++  0x53D7,
++  0x546A,
++  0x5BFF,
++  0x6388,
++  0x6A39,
++  0x7DAC,
++  0x9700,
++  0x56DA,
++  0x53CE,
++  0x5468,
++  0x5B97,
++  0x5C31,
++  0x5DDE,
++  0x4FEE,
++  0x6101,
++  0x62FE,
++  0x6D32,
++  0x79C0,
++  0x79CB,
++  0x7D42,
++  0x7E4D,
++  0x7FD2,
++  0x81ED,
++  0x821F,
++  0x8490,
++  0x8846,
++  0x8972,
++  0x8B90,
++  0x8E74,
++  0x8F2F,
++  0x9031,
++  0x914B,
++  0x916C,
++  0x96C6,
++  0x919C,
++  0x4EC0,
++  0x4F4F,
++  0x5145,
++  0x5341,
++  0x5F93,
++  0x620E,
++  0x67D4,
++  0x6C41,
++  0x6E0B,
++  0x7363,
++  0x7E26,
++  0x91CD,
++  0x9283,
++  0x53D4,
++  0x5919,
++  0x5BBF,
++  0x6DD1,
++  0x795D,
++  0x7E2E,
++  0x7C9B,
++  0x587E,
++  0x719F,
++  0x51FA,
++  0x8853,
++  0x8FF0,
++  0x4FCA,
++  0x5CFB,
++  0x6625,
++  0x77AC,
++  0x7AE3,
++  0x821C,
++  0x99FF,
++  0x51C6,
++  0x5FAA,
++  0x65EC,
++  0x696F,
++  0x6B89,
++  0x6DF3,
++  0x6E96,
++  0x6F64,
++  0x76FE,
++  0x7D14,
++  0x5DE1,
++  0x9075,
++  0x9187,
++  0x9806,
++  0x51E6,
++  0x521D,
++  0x6240,
++  0x6691,
++  0x66D9,
++  0x6E1A,
++  0x5EB6,
++  0x7DD2,
++  0x7F72,
++  0x66F8,
++  0x85AF,
++  0x85F7,
++  0x8AF8,
++  0x52A9,
++  0x53D9,
++  0x5973,
++  0x5E8F,
++  0x5F90,
++  0x6055,
++  0x92E4,
++  0x9664,
++  0x50B7,
++  0x511F,
++  0x52DD,
++  0x5320,
++  0x5347,
++  0x53EC,
++  0x54E8,
++  0x5546,
++  0x5531,
++  0x5617,
++  0x5968,
++  0x59BE,
++  0x5A3C,
++  0x5BB5,
++  0x5C06,
++  0x5C0F,
++  0x5C11,
++  0x5C1A,
++  0x5E84,
++  0x5E8A,
++  0x5EE0,
++  0x5F70,
++  0x627F,
++  0x6284,
++  0x62DB,
++  0x638C,
++  0x6377,
++  0x6607,
++  0x660C,
++  0x662D,
++  0x6676,
++  0x677E,
++  0x68A2,
++  0x6A1F,
++  0x6A35,
++  0x6CBC,
++  0x6D88,
++  0x6E09,
++  0x6E58,
++  0x713C,
++  0x7126,
++  0x7167,
++  0x75C7,
++  0x7701,
++  0x785D,
++  0x7901,
++  0x7965,
++  0x79F0,
++  0x7AE0,
++  0x7B11,
++  0x7CA7,
++  0x7D39,
++  0x8096,
++  0x83D6,
++  0x848B,
++  0x8549,
++  0x885D,
++  0x88F3,
++  0x8A1F,
++  0x8A3C,
++  0x8A54,
++  0x8A73,
++  0x8C61,
++  0x8CDE,
++  0x91A4,
++  0x9266,
++  0x937E,
++  0x9418,
++  0x969C,
++  0x9798,
++  0x4E0A,
++  0x4E08,
++  0x4E1E,
++  0x4E57,
++  0x5197,
++  0x5270,
++  0x57CE,
++  0x5834,
++  0x58CC,
++  0x5B22,
++  0x5E38,
++  0x60C5,
++  0x64FE,
++  0x6761,
++  0x6756,
++  0x6D44,
++  0x72B6,
++  0x7573,
++  0x7A63,
++  0x84B8,
++  0x8B72,
++  0x91B8,
++  0x9320,
++  0x5631,
++  0x57F4,
++  0x98FE,
++  0x62ED,
++  0x690D,
++  0x6B96,
++  0x71ED,
++  0x7E54,
++  0x8077,
++  0x8272,
++  0x89E6,
++  0x98DF,
++  0x8755,
++  0x8FB1,
++  0x5C3B,
++  0x4F38,
++  0x4FE1,
++  0x4FB5,
++  0x5507,
++  0x5A20,
++  0x5BDD,
++  0x5BE9,
++  0x5FC3,
++  0x614E,
++  0x632F,
++  0x65B0,
++  0x664B,
++  0x68EE,
++  0x699B,
++  0x6D78,
++  0x6DF1,
++  0x7533,
++  0x75B9,
++  0x771F,
++  0x795E,
++  0x79E6,
++  0x7D33,
++  0x81E3,
++  0x82AF,
++  0x85AA,
++  0x89AA,
++  0x8A3A,
++  0x8EAB,
++  0x8F9B,
++  0x9032,
++  0x91DD,
++  0x9707,
++  0x4EBA,
++  0x4EC1,
++  0x5203,
++  0x5875,
++  0x58EC,
++  0x5C0B,
++  0x751A,
++  0x5C3D,
++  0x814E,
++  0x8A0A,
++  0x8FC5,
++  0x9663,
++  0x976D,
++  0x7B25,
++  0x8ACF,
++  0x9808,
++  0x9162,
++  0x56F3,
++  0x53A8,
++  0x9017,
++  0x5439,
++  0x5782,
++  0x5E25,
++  0x63A8,
++  0x6C34,
++  0x708A,
++  0x7761,
++  0x7C8B,
++  0x7FE0,
++  0x8870,
++  0x9042,
++  0x9154,
++  0x9310,
++  0x9318,
++  0x968F,
++  0x745E,
++  0x9AC4,
++  0x5D07,
++  0x5D69,
++  0x6570,
++  0x67A2,
++  0x8DA8,
++  0x96DB,
++  0x636E,
++  0x6749,
++  0x6919,
++  0x83C5,
++  0x9817,
++  0x96C0,
++  0x88FE,
++  0x6F84,
++  0x647A,
++  0x5BF8,
++  0x4E16,
++  0x702C,
++  0x755D,
++  0x662F,
++  0x51C4,
++  0x5236,
++  0x52E2,
++  0x59D3,
++  0x5F81,
++  0x6027,
++  0x6210,
++  0x653F,
++  0x6574,
++  0x661F,
++  0x6674,
++  0x68F2,
++  0x6816,
++  0x6B63,
++  0x6E05,
++  0x7272,
++  0x751F,
++  0x76DB,
++  0x7CBE,
++  0x8056,
++  0x58F0,
++  0x88FD,
++  0x897F,
++  0x8AA0,
++  0x8A93,
++  0x8ACB,
++  0x901D,
++  0x9192,
++  0x9752,
++  0x9759,
++  0x6589,
++  0x7A0E,
++  0x8106,
++  0x96BB,
++  0x5E2D,
++  0x60DC,
++  0x621A,
++  0x65A5,
++  0x6614,
++  0x6790,
++  0x77F3,
++  0x7A4D,
++  0x7C4D,
++  0x7E3E,
++  0x810A,
++  0x8CAC,
++  0x8D64,
++  0x8DE1,
++  0x8E5F,
++  0x78A9,
++  0x5207,
++  0x62D9,
++  0x63A5,
++  0x6442,
++  0x6298,
++  0x8A2D,
++  0x7A83,
++  0x7BC0,
++  0x8AAC,
++  0x96EA,
++  0x7D76,
++  0x820C,
++  0x8749,
++  0x4ED9,
++  0x5148,
++  0x5343,
++  0x5360,
++  0x5BA3,
++  0x5C02,
++  0x5C16,
++  0x5DDD,
++  0x6226,
++  0x6247,
++  0x64B0,
++  0x6813,
++  0x6834,
++  0x6CC9,
++  0x6D45,
++  0x6D17,
++  0x67D3,
++  0x6F5C,
++  0x714E,
++  0x717D,
++  0x65CB,
++  0x7A7F,
++  0x7BAD,
++  0x7DDA,
++  0x7E4A,
++  0x7FA8,
++  0x817A,
++  0x821B,
++  0x8239,
++  0x85A6,
++  0x8A6E,
++  0x8CCE,
++  0x8DF5,
++  0x9078,
++  0x9077,
++  0x92AD,
++  0x9291,
++  0x9583,
++  0x9BAE,
++  0x524D,
++  0x5584,
++  0x6F38,
++  0x7136,
++  0x5168,
++  0x7985,
++  0x7E55,
++  0x81B3,
++  0x7CCE,
++  0x564C,
++  0x5851,
++  0x5CA8,
++  0x63AA,
++  0x66FE,
++  0x66FD,
++  0x695A,
++  0x72D9,
++  0x758F,
++  0x758E,
++  0x790E,
++  0x7956,
++  0x79DF,
++  0x7C97,
++  0x7D20,
++  0x7D44,
++  0x8607,
++  0x8A34,
++  0x963B,
++  0x9061,
++  0x9F20,
++  0x50E7,
++  0x5275,
++  0x53CC,
++  0x53E2,
++  0x5009,
++  0x55AA,
++  0x58EE,
++  0x594F,
++  0x723D,
++  0x5B8B,
++  0x5C64,
++  0x531D,
++  0x60E3,
++  0x60F3,
++  0x635C,
++  0x6383,
++  0x633F,
++  0x63BB,
++  0x64CD,
++  0x65E9,
++  0x66F9,
++  0x5DE3,
++  0x69CD,
++  0x69FD,
++  0x6F15,
++  0x71E5,
++  0x4E89,
++  0x75E9,
++  0x76F8,
++  0x7A93,
++  0x7CDF,
++  0x7DCF,
++  0x7D9C,
++  0x8061,
++  0x8349,
++  0x8358,
++  0x846C,
++  0x84BC,
++  0x85FB,
++  0x88C5,
++  0x8D70,
++  0x9001,
++  0x906D,
++  0x9397,
++  0x971C,
++  0x9A12,
++  0x50CF,
++  0x5897,
++  0x618E,
++  0x81D3,
++  0x8535,
++  0x8D08,
++  0x9020,
++  0x4FC3,
++  0x5074,
++  0x5247,
++  0x5373,
++  0x606F,
++  0x6349,
++  0x675F,
++  0x6E2C,
++  0x8DB3,
++  0x901F,
++  0x4FD7,
++  0x5C5E,
++  0x8CCA,
++  0x65CF,
++  0x7D9A,
++  0x5352,
++  0x8896,
++  0x5176,
++  0x63C3,
++  0x5B58,
++  0x5B6B,
++  0x5C0A,
++  0x640D,
++  0x6751,
++  0x905C,
++  0x4ED6,
++  0x591A,
++  0x592A,
++  0x6C70,
++  0x8A51,
++  0x553E,
++  0x5815,
++  0x59A5,
++  0x60F0,
++  0x6253,
++  0x67C1,
++  0x8235,
++  0x6955,
++  0x9640,
++  0x99C4,
++  0x9A28,
++  0x4F53,
++  0x5806,
++  0x5BFE,
++  0x8010,
++  0x5CB1,
++  0x5E2F,
++  0x5F85,
++  0x6020,
++  0x614B,
++  0x6234,
++  0x66FF,
++  0x6CF0,
++  0x6EDE,
++  0x80CE,
++  0x817F,
++  0x82D4,
++  0x888B,
++  0x8CB8,
++  0x9000,
++  0x902E,
++  0x968A,
++  0x9EDB,
++  0x9BDB,
++  0x4EE3,
++  0x53F0,
++  0x5927,
++  0x7B2C,
++  0x918D,
++  0x984C,
++  0x9DF9,
++  0x6EDD,
++  0x7027,
++  0x5353,
++  0x5544,
++  0x5B85,
++  0x6258,
++  0x629E,
++  0x62D3,
++  0x6CA2,
++  0x6FEF,
++  0x7422,
++  0x8A17,
++  0x9438,
++  0x6FC1,
++  0x8AFE,
++  0x8338,
++  0x51E7,
++  0x86F8,
++  0x53EA,
++  0x53E9,
++  0x4F46,
++  0x9054,
++  0x8FB0,
++  0x596A,
++  0x8131,
++  0x5DFD,
++  0x7AEA,
++  0x8FBF,
++  0x68DA,
++  0x8C37,
++  0x72F8,
++  0x9C48,
++  0x6A3D,
++  0x8AB0,
++  0x4E39,
++  0x5358,
++  0x5606,
++  0x5766,
++  0x62C5,
++  0x63A2,
++  0x65E6,
++  0x6B4E,
++  0x6DE1,
++  0x6E5B,
++  0x70AD,
++  0x77ED,
++  0x7AEF,
++  0x7BAA,
++  0x7DBB,
++  0x803D,
++  0x80C6,
++  0x86CB,
++  0x8A95,
++  0x935B,
++  0x56E3,
++  0x58C7,
++  0x5F3E,
++  0x65AD,
++  0x6696,
++  0x6A80,
++  0x6BB5,
++  0x7537,
++  0x8AC7,
++  0x5024,
++  0x77E5,
++  0x5730,
++  0x5F1B,
++  0x6065,
++  0x667A,
++  0x6C60,
++  0x75F4,
++  0x7A1A,
++  0x7F6E,
++  0x81F4,
++  0x8718,
++  0x9045,
++  0x99B3,
++  0x7BC9,
++  0x755C,
++  0x7AF9,
++  0x7B51,
++  0x84C4,
++  0x9010,
++  0x79E9,
++  0x7A92,
++  0x8336,
++  0x5AE1,
++  0x7740,
++  0x4E2D,
++  0x4EF2,
++  0x5B99,
++  0x5FE0,
++  0x62BD,
++  0x663C,
++  0x67F1,
++  0x6CE8,
++  0x866B,
++  0x8877,
++  0x8A3B,
++  0x914E,
++  0x92F3,
++  0x99D0,
++  0x6A17,
++  0x7026,
++  0x732A,
++  0x82E7,
++  0x8457,
++  0x8CAF,
++  0x4E01,
++  0x5146,
++  0x51CB,
++  0x558B,
++  0x5BF5,
++  0x5E16,
++  0x5E33,
++  0x5E81,
++  0x5F14,
++  0x5F35,
++  0x5F6B,
++  0x5FB4,
++  0x61F2,
++  0x6311,
++  0x66A2,
++  0x671D,
++  0x6F6E,
++  0x7252,
++  0x753A,
++  0x773A,
++  0x8074,
++  0x8139,
++  0x8178,
++  0x8776,
++  0x8ABF,
++  0x8ADC,
++  0x8D85,
++  0x8DF3,
++  0x929A,
++  0x9577,
++  0x9802,
++  0x9CE5,
++  0x52C5,
++  0x6357,
++  0x76F4,
++  0x6715,
++  0x6C88,
++  0x73CD,
++  0x8CC3,
++  0x93AE,
++  0x9673,
++  0x6D25,
++  0x589C,
++  0x690E,
++  0x69CC,
++  0x8FFD,
++  0x939A,
++  0x75DB,
++  0x901A,
++  0x585A,
++  0x6802,
++  0x63B4,
++  0x69FB,
++  0x4F43,
++  0x6F2C,
++  0x67D8,
++  0x8FBB,
++  0x8526,
++  0x7DB4,
++  0x9354,
++  0x693F,
++  0x6F70,
++  0x576A,
++  0x58F7,
++  0x5B2C,
++  0x7D2C,
++  0x722A,
++  0x540A,
++  0x91E3,
++  0x9DB4,
++  0x4EAD,
++  0x4F4E,
++  0x505C,
++  0x5075,
++  0x5243,
++  0x8C9E,
++  0x5448,
++  0x5824,
++  0x5B9A,
++  0x5E1D,
++  0x5E95,
++  0x5EAD,
++  0x5EF7,
++  0x5F1F,
++  0x608C,
++  0x62B5,
++  0x633A,
++  0x63D0,
++  0x68AF,
++  0x6C40,
++  0x7887,
++  0x798E,
++  0x7A0B,
++  0x7DE0,
++  0x8247,
++  0x8A02,
++  0x8AE6,
++  0x8E44,
++  0x9013,
++  0x90B8,
++  0x912D,
++  0x91D8,
++  0x9F0E,
++  0x6CE5,
++  0x6458,
++  0x64E2,
++  0x6575,
++  0x6EF4,
++  0x7684,
++  0x7B1B,
++  0x9069,
++  0x93D1,
++  0x6EBA,
++  0x54F2,
++  0x5FB9,
++  0x64A4,
++  0x8F4D,
++  0x8FED,
++  0x9244,
++  0x5178,
++  0x586B,
++  0x5929,
++  0x5C55,
++  0x5E97,
++  0x6DFB,
++  0x7E8F,
++  0x751C,
++  0x8CBC,
++  0x8EE2,
++  0x985B,
++  0x70B9,
++  0x4F1D,
++  0x6BBF,
++  0x6FB1,
++  0x7530,
++  0x96FB,
++  0x514E,
++  0x5410,
++  0x5835,
++  0x5857,
++  0x59AC,
++  0x5C60,
++  0x5F92,
++  0x6597,
++  0x675C,
++  0x6E21,
++  0x767B,
++  0x83DF,
++  0x8CED,
++  0x9014,
++  0x90FD,
++  0x934D,
++  0x7825,
++  0x783A,
++  0x52AA,
++  0x5EA6,
++  0x571F,
++  0x5974,
++  0x6012,
++  0x5012,
++  0x515A,
++  0x51AC,
++  0x51CD,
++  0x5200,
++  0x5510,
++  0x5854,
++  0x5858,
++  0x5957,
++  0x5B95,
++  0x5CF6,
++  0x5D8B,
++  0x60BC,
++  0x6295,
++  0x642D,
++  0x6771,
++  0x6843,
++  0x68BC,
++  0x68DF,
++  0x76D7,
++  0x6DD8,
++  0x6E6F,
++  0x6D9B,
++  0x706F,
++  0x71C8,
++  0x5F53,
++  0x75D8,
++  0x7977,
++  0x7B49,
++  0x7B54,
++  0x7B52,
++  0x7CD6,
++  0x7D71,
++  0x5230,
++  0x8463,
++  0x8569,
++  0x85E4,
++  0x8A0E,
++  0x8B04,
++  0x8C46,
++  0x8E0F,
++  0x9003,
++  0x900F,
++  0x9419,
++  0x9676,
++  0x982D,
++  0x9A30,
++  0x95D8,
++  0x50CD,
++  0x52D5,
++  0x540C,
++  0x5802,
++  0x5C0E,
++  0x61A7,
++  0x649E,
++  0x6D1E,
++  0x77B3,
++  0x7AE5,
++  0x80F4,
++  0x8404,
++  0x9053,
++  0x9285,
++  0x5CE0,
++  0x9D07,
++  0x533F,
++  0x5F97,
++  0x5FB3,
++  0x6D9C,
++  0x7279,
++  0x7763,
++  0x79BF,
++  0x7BE4,
++  0x6BD2,
++  0x72EC,
++  0x8AAD,
++  0x6803,
++  0x6A61,
++  0x51F8,
++  0x7A81,
++  0x6934,
++  0x5C4A,
++  0x9CF6,
++  0x82EB,
++  0x5BC5,
++  0x9149,
++  0x701E,
++  0x5678,
++  0x5C6F,
++  0x60C7,
++  0x6566,
++  0x6C8C,
++  0x8C5A,
++  0x9041,
++  0x9813,
++  0x5451,
++  0x66C7,
++  0x920D,
++  0x5948,
++  0x90A3,
++  0x5185,
++  0x4E4D,
++  0x51EA,
++  0x8599,
++  0x8B0E,
++  0x7058,
++  0x637A,
++  0x934B,
++  0x6962,
++  0x99B4,
++  0x7E04,
++  0x7577,
++  0x5357,
++  0x6960,
++  0x8EDF,
++  0x96E3,
++  0x6C5D,
++  0x4E8C,
++  0x5C3C,
++  0x5F10,
++  0x8FE9,
++  0x5302,
++  0x8CD1,
++  0x8089,
++  0x8679,
++  0x5EFF,
++  0x65E5,
++  0x4E73,
++  0x5165,
++  0x5982,
++  0x5C3F,
++  0x97EE,
++  0x4EFB,
++  0x598A,
++  0x5FCD,
++  0x8A8D,
++  0x6FE1,
++  0x79B0,
++  0x7962,
++  0x5BE7,
++  0x8471,
++  0x732B,
++  0x71B1,
++  0x5E74,
++  0x5FF5,
++  0x637B,
++  0x649A,
++  0x71C3,
++  0x7C98,
++  0x4E43,
++  0x5EFC,
++  0x4E4B,
++  0x57DC,
++  0x56A2,
++  0x60A9,
++  0x6FC3,
++  0x7D0D,
++  0x80FD,
++  0x8133,
++  0x81BF,
++  0x8FB2,
++  0x8997,
++  0x86A4,
++  0x5DF4,
++  0x628A,
++  0x64AD,
++  0x8987,
++  0x6777,
++  0x6CE2,
++  0x6D3E,
++  0x7436,
++  0x7834,
++  0x5A46,
++  0x7F75,
++  0x82AD,
++  0x99AC,
++  0x4FF3,
++  0x5EC3,
++  0x62DD,
++  0x6392,
++  0x6557,
++  0x676F,
++  0x76C3,
++  0x724C,
++  0x80CC,
++  0x80BA,
++  0x8F29,
++  0x914D,
++  0x500D,
++  0x57F9,
++  0x5A92,
++  0x6885,
++  0x6973,
++  0x7164,
++  0x72FD,
++  0x8CB7,
++  0x58F2,
++  0x8CE0,
++  0x966A,
++  0x9019,
++  0x877F,
++  0x79E4,
++  0x77E7,
++  0x8429,
++  0x4F2F,
++  0x5265,
++  0x535A,
++  0x62CD,
++  0x67CF,
++  0x6CCA,
++  0x767D,
++  0x7B94,
++  0x7C95,
++  0x8236,
++  0x8584,
++  0x8FEB,
++  0x66DD,
++  0x6F20,
++  0x7206,
++  0x7E1B,
++  0x83AB,
++  0x99C1,
++  0x9EA6,
++  0x51FD,
++  0x7BB1,
++  0x7872,
++  0x7BB8,
++  0x8087,
++  0x7B48,
++  0x6AE8,
++  0x5E61,
++  0x808C,
++  0x7551,
++  0x7560,
++  0x516B,
++  0x9262,
++  0x6E8C,
++  0x767A,
++  0x9197,
++  0x9AEA,
++  0x4F10,
++  0x7F70,
++  0x629C,
++  0x7B4F,
++  0x95A5,
++  0x9CE9,
++  0x567A,
++  0x5859,
++  0x86E4,
++  0x96BC,
++  0x4F34,
++  0x5224,
++  0x534A,
++  0x53CD,
++  0x53DB,
++  0x5E06,
++  0x642C,
++  0x6591,
++  0x677F,
++  0x6C3E,
++  0x6C4E,
++  0x7248,
++  0x72AF,
++  0x73ED,
++  0x7554,
++  0x7E41,
++  0x822C,
++  0x85E9,
++  0x8CA9,
++  0x7BC4,
++  0x91C6,
++  0x7169,
++  0x9812,
++  0x98EF,
++  0x633D,
++  0x6669,
++  0x756A,
++  0x76E4,
++  0x78D0,
++  0x8543,
++  0x86EE,
++  0x532A,
++  0x5351,
++  0x5426,
++  0x5983,
++  0x5E87,
++  0x5F7C,
++  0x60B2,
++  0x6249,
++  0x6279,
++  0x62AB,
++  0x6590,
++  0x6BD4,
++  0x6CCC,
++  0x75B2,
++  0x76AE,
++  0x7891,
++  0x79D8,
++  0x7DCB,
++  0x7F77,
++  0x80A5,
++  0x88AB,
++  0x8AB9,
++  0x8CBB,
++  0x907F,
++  0x975E,
++  0x98DB,
++  0x6A0B,
++  0x7C38,
++  0x5099,
++  0x5C3E,
++  0x5FAE,
++  0x6787,
++  0x6BD8,
++  0x7435,
++  0x7709,
++  0x7F8E,
++  0x9F3B,
++  0x67CA,
++  0x7A17,
++  0x5339,
++  0x758B,
++  0x9AED,
++  0x5F66,
++  0x819D,
++  0x83F1,
++  0x8098,
++  0x5F3C,
++  0x5FC5,
++  0x7562,
++  0x7B46,
++  0x903C,
++  0x6867,
++  0x59EB,
++  0x5A9B,
++  0x7D10,
++  0x767E,
++  0x8B2C,
++  0x4FF5,
++  0x5F6A,
++  0x6A19,
++  0x6C37,
++  0x6F02,
++  0x74E2,
++  0x7968,
++  0x8868,
++  0x8A55,
++  0x8C79,
++  0x5EDF,
++  0x63CF,
++  0x75C5,
++  0x79D2,
++  0x82D7,
++  0x9328,
++  0x92F2,
++  0x849C,
++  0x86ED,
++  0x9C2D,
++  0x54C1,
++  0x5F6C,
++  0x658C,
++  0x6D5C,
++  0x7015,
++  0x8CA7,
++  0x8CD3,
++  0x983B,
++  0x654F,
++  0x74F6,
++  0x4E0D,
++  0x4ED8,
++  0x57E0,
++  0x592B,
++  0x5A66,
++  0x5BCC,
++  0x51A8,
++  0x5E03,
++  0x5E9C,
++  0x6016,
++  0x6276,
++  0x6577,
++  0x65A7,
++  0x666E,
++  0x6D6E,
++  0x7236,
++  0x7B26,
++  0x8150,
++  0x819A,
++  0x8299,
++  0x8B5C,
++  0x8CA0,
++  0x8CE6,
++  0x8D74,
++  0x961C,
++  0x9644,
++  0x4FAE,
++  0x64AB,
++  0x6B66,
++  0x821E,
++  0x8461,
++  0x856A,
++  0x90E8,
++  0x5C01,
++  0x6953,
++  0x98A8,
++  0x847A,
++  0x8557,
++  0x4F0F,
++  0x526F,
++  0x5FA9,
++  0x5E45,
++  0x670D,
++  0x798F,
++  0x8179,
++  0x8907,
++  0x8986,
++  0x6DF5,
++  0x5F17,
++  0x6255,
++  0x6CB8,
++  0x4ECF,
++  0x7269,
++  0x9B92,
++  0x5206,
++  0x543B,
++  0x5674,
++  0x58B3,
++  0x61A4,
++  0x626E,
++  0x711A,
++  0x596E,
++  0x7C89,
++  0x7CDE,
++  0x7D1B,
++  0x96F0,
++  0x6587,
++  0x805E,
++  0x4E19,
++  0x4F75,
++  0x5175,
++  0x5840,
++  0x5E63,
++  0x5E73,
++  0x5F0A,
++  0x67C4,
++  0x4E26,
++  0x853D,
++  0x9589,
++  0x965B,
++  0x7C73,
++  0x9801,
++  0x50FB,
++  0x58C1,
++  0x7656,
++  0x78A7,
++  0x5225,
++  0x77A5,
++  0x8511,
++  0x7B86,
++  0x504F,
++  0x5909,
++  0x7247,
++  0x7BC7,
++  0x7DE8,
++  0x8FBA,
++  0x8FD4,
++  0x904D,
++  0x4FBF,
++  0x52C9,
++  0x5A29,
++  0x5F01,
++  0x97AD,
++  0x4FDD,
++  0x8217,
++  0x92EA,
++  0x5703,
++  0x6355,
++  0x6B69,
++  0x752B,
++  0x88DC,
++  0x8F14,
++  0x7A42,
++  0x52DF,
++  0x5893,
++  0x6155,
++  0x620A,
++  0x66AE,
++  0x6BCD,
++  0x7C3F,
++  0x83E9,
++  0x5023,
++  0x4FF8,
++  0x5305,
++  0x5446,
++  0x5831,
++  0x5949,
++  0x5B9D,
++  0x5CF0,
++  0x5CEF,
++  0x5D29,
++  0x5E96,
++  0x62B1,
++  0x6367,
++  0x653E,
++  0x65B9,
++  0x670B,
++  0x6CD5,
++  0x6CE1,
++  0x70F9,
++  0x7832,
++  0x7E2B,
++  0x80DE,
++  0x82B3,
++  0x840C,
++  0x84EC,
++  0x8702,
++  0x8912,
++  0x8A2A,
++  0x8C4A,
++  0x90A6,
++  0x92D2,
++  0x98FD,
++  0x9CF3,
++  0x9D6C,
++  0x4E4F,
++  0x4EA1,
++  0x508D,
++  0x5256,
++  0x574A,
++  0x59A8,
++  0x5E3D,
++  0x5FD8,
++  0x5FD9,
++  0x623F,
++  0x66B4,
++  0x671B,
++  0x67D0,
++  0x68D2,
++  0x5192,
++  0x7D21,
++  0x80AA,
++  0x81A8,
++  0x8B00,
++  0x8C8C,
++  0x8CBF,
++  0x927E,
++  0x9632,
++  0x5420,
++  0x982C,
++  0x5317,
++  0x50D5,
++  0x535C,
++  0x58A8,
++  0x64B2,
++  0x6734,
++  0x7267,
++  0x7766,
++  0x7A46,
++  0x91E6,
++  0x52C3,
++  0x6CA1,
++  0x6B86,
++  0x5800,
++  0x5E4C,
++  0x5954,
++  0x672C,
++  0x7FFB,
++  0x51E1,
++  0x76C6,
++  0x6469,
++  0x78E8,
++  0x9B54,
++  0x9EBB,
++  0x57CB,
++  0x59B9,
++  0x6627,
++  0x679A,
++  0x6BCE,
++  0x54E9,
++  0x69D9,
++  0x5E55,
++  0x819C,
++  0x6795,
++  0x9BAA,
++  0x67FE,
++  0x9C52,
++  0x685D,
++  0x4EA6,
++  0x4FE3,
++  0x53C8,
++  0x62B9,
++  0x672B,
++  0x6CAB,
++  0x8FC4,
++  0x4FAD,
++  0x7E6D,
++  0x9EBF,
++  0x4E07,
++  0x6162,
++  0x6E80,
++  0x6F2B,
++  0x8513,
++  0x5473,
++  0x672A,
++  0x9B45,
++  0x5DF3,
++  0x7B95,
++  0x5CAC,
++  0x5BC6,
++  0x871C,
++  0x6E4A,
++  0x84D1,
++  0x7A14,
++  0x8108,
++  0x5999,
++  0x7C8D,
++  0x6C11,
++  0x7720,
++  0x52D9,
++  0x5922,
++  0x7121,
++  0x725F,
++  0x77DB,
++  0x9727,
++  0x9D61,
++  0x690B,
++  0x5A7F,
++  0x5A18,
++  0x51A5,
++  0x540D,
++  0x547D,
++  0x660E,
++  0x76DF,
++  0x8FF7,
++  0x9298,
++  0x9CF4,
++  0x59EA,
++  0x725D,
++  0x6EC5,
++  0x514D,
++  0x68C9,
++  0x7DBF,
++  0x7DEC,
++  0x9762,
++  0x9EBA,
++  0x6478,
++  0x6A21,
++  0x8302,
++  0x5984,
++  0x5B5F,
++  0x6BDB,
++  0x731B,
++  0x76F2,
++  0x7DB2,
++  0x8017,
++  0x8499,
++  0x5132,
++  0x6728,
++  0x9ED9,
++  0x76EE,
++  0x6762,
++  0x52FF,
++  0x9905,
++  0x5C24,
++  0x623B,
++  0x7C7E,
++  0x8CB0,
++  0x554F,
++  0x60B6,
++  0x7D0B,
++  0x9580,
++  0x5301,
++  0x4E5F,
++  0x51B6,
++  0x591C,
++  0x723A,
++  0x8036,
++  0x91CE,
++  0x5F25,
++  0x77E2,
++  0x5384,
++  0x5F79,
++  0x7D04,
++  0x85AC,
++  0x8A33,
++  0x8E8D,
++  0x9756,
++  0x67F3,
++  0x85AE,
++  0x9453,
++  0x6109,
++  0x6108,
++  0x6CB9,
++  0x7652,
++  0x8AED,
++  0x8F38,
++  0x552F,
++  0x4F51,
++  0x512A,
++  0x52C7,
++  0x53CB,
++  0x5BA5,
++  0x5E7D,
++  0x60A0,
++  0x6182,
++  0x63D6,
++  0x6709,
++  0x67DA,
++  0x6E67,
++  0x6D8C,
++  0x7336,
++  0x7337,
++  0x7531,
++  0x7950,
++  0x88D5,
++  0x8A98,
++  0x904A,
++  0x9091,
++  0x90F5,
++  0x96C4,
++  0x878D,
++  0x5915,
++  0x4E88,
++  0x4F59,
++  0x4E0E,
++  0x8A89,
++  0x8F3F,
++  0x9810,
++  0x50AD,
++  0x5E7C,
++  0x5996,
++  0x5BB9,
++  0x5EB8,
++  0x63DA,
++  0x63FA,
++  0x64C1,
++  0x66DC,
++  0x694A,
++  0x69D8,
++  0x6D0B,
++  0x6EB6,
++  0x7194,
++  0x7528,
++  0x7AAF,
++  0x7F8A,
++  0x8000,
++  0x8449,
++  0x84C9,
++  0x8981,
++  0x8B21,
++  0x8E0A,
++  0x9065,
++  0x967D,
++  0x990A,
++  0x617E,
++  0x6291,
++  0x6B32,
++  0x6C83,
++  0x6D74,
++  0x7FCC,
++  0x7FFC,
++  0x6DC0,
++  0x7F85,
++  0x87BA,
++  0x88F8,
++  0x6765,
++  0x83B1,
++  0x983C,
++  0x96F7,
++  0x6D1B,
++  0x7D61,
++  0x843D,
++  0x916A,
++  0x4E71,
++  0x5375,
++  0x5D50,
++  0x6B04,
++  0x6FEB,
++  0x85CD,
++  0x862D,
++  0x89A7,
++  0x5229,
++  0x540F,
++  0x5C65,
++  0x674E,
++  0x68A8,
++  0x7406,
++  0x7483,
++  0x75E2,
++  0x88CF,
++  0x88E1,
++  0x91CC,
++  0x96E2,
++  0x9678,
++  0x5F8B,
++  0x7387,
++  0x7ACB,
++  0x844E,
++  0x63A0,
++  0x7565,
++  0x5289,
++  0x6D41,
++  0x6E9C,
++  0x7409,
++  0x7559,
++  0x786B,
++  0x7C92,
++  0x9686,
++  0x7ADC,
++  0x9F8D,
++  0x4FB6,
++  0x616E,
++  0x65C5,
++  0x865C,
++  0x4E86,
++  0x4EAE,
++  0x50DA,
++  0x4E21,
++  0x51CC,
++  0x5BEE,
++  0x6599,
++  0x6881,
++  0x6DBC,
++  0x731F,
++  0x7642,
++  0x77AD,
++  0x7A1C,
++  0x7CE7,
++  0x826F,
++  0x8AD2,
++  0x907C,
++  0x91CF,
++  0x9675,
++  0x9818,
++  0x529B,
++  0x7DD1,
++  0x502B,
++  0x5398,
++  0x6797,
++  0x6DCB,
++  0x71D0,
++  0x7433,
++  0x81E8,
++  0x8F2A,
++  0x96A3,
++  0x9C57,
++  0x9E9F,
++  0x7460,
++  0x5841,
++  0x6D99,
++  0x7D2F,
++  0x985E,
++  0x4EE4,
++  0x4F36,
++  0x4F8B,
++  0x51B7,
++  0x52B1,
++  0x5DBA,
++  0x601C,
++  0x73B2,
++  0x793C,
++  0x82D3,
++  0x9234,
++  0x96B7,
++  0x96F6,
++  0x970A,
++  0x9E97,
++  0x9F62,
++  0x66A6,
++  0x6B74,
++  0x5217,
++  0x52A3,
++  0x70C8,
++  0x88C2,
++  0x5EC9,
++  0x604B,
++  0x6190,
++  0x6F23,
++  0x7149,
++  0x7C3E,
++  0x7DF4,
++  0x806F,
++  0x84EE,
++  0x9023,
++  0x932C,
++  0x5442,
++  0x9B6F,
++  0x6AD3,
++  0x7089,
++  0x8CC2,
++  0x8DEF,
++  0x9732,
++  0x52B4,
++  0x5A41,
++  0x5ECA,
++  0x5F04,
++  0x6717,
++  0x697C,
++  0x6994,
++  0x6D6A,
++  0x6F0F,
++  0x7262,
++  0x72FC,
++  0x7BED,
++  0x8001,
++  0x807E,
++  0x874B,
++  0x90CE,
++  0x516D,
++  0x9E93,
++  0x7984,
++  0x808B,
++  0x9332,
++  0x8AD6,
++  0x502D,
++  0x548C,
++  0x8A71,
++  0x6B6A,
++  0x8CC4,
++  0x8107,
++  0x60D1,
++  0x67A0,
++  0x9DF2,
++  0x4E99,
++  0x4E98,
++  0x9C10,
++  0x8A6B,
++  0x85C1,
++  0x8568,
++  0x6900,
++  0x6E7E,
++  0x7897,
++  0x8155
++};
++
++/* d0a1 to f4a6 is contiguous */
++
++static unsigned short d02f4[] = {
++  0x5F0C,
++  0x4E10,
++  0x4E15,
++  0x4E2A,
++  0x4E31,
++  0x4E36,
++  0x4E3C,
++  0x4E3F,
++  0x4E42,
++  0x4E56,
++  0x4E58,
++  0x4E82,
++  0x4E85,
++  0x8C6B,
++  0x4E8A,
++  0x8212,
++  0x5F0D,
++  0x4E8E,
++  0x4E9E,
++  0x4E9F,
++  0x4EA0,
++  0x4EA2,
++  0x4EB0,
++  0x4EB3,
++  0x4EB6,
++  0x4ECE,
++  0x4ECD,
++  0x4EC4,
++  0x4EC6,
++  0x4EC2,
++  0x4ED7,
++  0x4EDE,
++  0x4EED,
++  0x4EDF,
++  0x4EF7,
++  0x4F09,
++  0x4F5A,
++  0x4F30,
++  0x4F5B,
++  0x4F5D,
++  0x4F57,
++  0x4F47,
++  0x4F76,
++  0x4F88,
++  0x4F8F,
++  0x4F98,
++  0x4F7B,
++  0x4F69,
++  0x4F70,
++  0x4F91,
++  0x4F6F,
++  0x4F86,
++  0x4F96,
++  0x5118,
++  0x4FD4,
++  0x4FDF,
++  0x4FCE,
++  0x4FD8,
++  0x4FDB,
++  0x4FD1,
++  0x4FDA,
++  0x4FD0,
++  0x4FE4,
++  0x4FE5,
++  0x501A,
++  0x5028,
++  0x5014,
++  0x502A,
++  0x5025,
++  0x5005,
++  0x4F1C,
++  0x4FF6,
++  0x5021,
++  0x5029,
++  0x502C,
++  0x4FFE,
++  0x4FEF,
++  0x5011,
++  0x5006,
++  0x5043,
++  0x5047,
++  0x6703,
++  0x5055,
++  0x5050,
++  0x5048,
++  0x505A,
++  0x5056,
++  0x506C,
++  0x5078,
++  0x5080,
++  0x509A,
++  0x5085,
++  0x50B4,
++  0x50B2,
++  0x50C9,
++  0x50CA,
++  0x50B3,
++  0x50C2,
++  0x50D6,
++  0x50DE,
++  0x50E5,
++  0x50ED,
++  0x50E3,
++  0x50EE,
++  0x50F9,
++  0x50F5,
++  0x5109,
++  0x5101,
++  0x5102,
++  0x5116,
++  0x5115,
++  0x5114,
++  0x511A,
++  0x5121,
++  0x513A,
++  0x5137,
++  0x513C,
++  0x513B,
++  0x513F,
++  0x5140,
++  0x5152,
++  0x514C,
++  0x5154,
++  0x5162,
++  0x7AF8,
++  0x5169,
++  0x516A,
++  0x516E,
++  0x5180,
++  0x5182,
++  0x56D8,
++  0x518C,
++  0x5189,
++  0x518F,
++  0x5191,
++  0x5193,
++  0x5195,
++  0x5196,
++  0x51A4,
++  0x51A6,
++  0x51A2,
++  0x51A9,
++  0x51AA,
++  0x51AB,
++  0x51B3,
++  0x51B1,
++  0x51B2,
++  0x51B0,
++  0x51B5,
++  0x51BD,
++  0x51C5,
++  0x51C9,
++  0x51DB,
++  0x51E0,
++  0x8655,
++  0x51E9,
++  0x51ED,
++  0x51F0,
++  0x51F5,
++  0x51FE,
++  0x5204,
++  0x520B,
++  0x5214,
++  0x520E,
++  0x5227,
++  0x522A,
++  0x522E,
++  0x5233,
++  0x5239,
++  0x524F,
++  0x5244,
++  0x524B,
++  0x524C,
++  0x525E,
++  0x5254,
++  0x526A,
++  0x5274,
++  0x5269,
++  0x5273,
++  0x527F,
++  0x527D,
++  0x528D,
++  0x5294,
++  0x5292,
++  0x5271,
++  0x5288,
++  0x5291,
++  0x8FA8,
++  0x8FA7,
++  0x52AC,
++  0x52AD,
++  0x52BC,
++  0x52B5,
++  0x52C1,
++  0x52CD,
++  0x52D7,
++  0x52DE,
++  0x52E3,
++  0x52E6,
++  0x98ED,
++  0x52E0,
++  0x52F3,
++  0x52F5,
++  0x52F8,
++  0x52F9,
++  0x5306,
++  0x5308,
++  0x7538,
++  0x530D,
++  0x5310,
++  0x530F,
++  0x5315,
++  0x531A,
++  0x5323,
++  0x532F,
++  0x5331,
++  0x5333,
++  0x5338,
++  0x5340,
++  0x5346,
++  0x5345,
++  0x4E17,
++  0x5349,
++  0x534D,
++  0x51D6,
++  0x535E,
++  0x5369,
++  0x536E,
++  0x5918,
++  0x537B,
++  0x5377,
++  0x5382,
++  0x5396,
++  0x53A0,
++  0x53A6,
++  0x53A5,
++  0x53AE,
++  0x53B0,
++  0x53B6,
++  0x53C3,
++  0x7C12,
++  0x96D9,
++  0x53DF,
++  0x66FC,
++  0x71EE,
++  0x53EE,
++  0x53E8,
++  0x53ED,
++  0x53FA,
++  0x5401,
++  0x543D,
++  0x5440,
++  0x542C,
++  0x542D,
++  0x543C,
++  0x542E,
++  0x5436,
++  0x5429,
++  0x541D,
++  0x544E,
++  0x548F,
++  0x5475,
++  0x548E,
++  0x545F,
++  0x5471,
++  0x5477,
++  0x5470,
++  0x5492,
++  0x547B,
++  0x5480,
++  0x5476,
++  0x5484,
++  0x5490,
++  0x5486,
++  0x54C7,
++  0x54A2,
++  0x54B8,
++  0x54A5,
++  0x54AC,
++  0x54C4,
++  0x54C8,
++  0x54A8,
++  0x54AB,
++  0x54C2,
++  0x54A4,
++  0x54BE,
++  0x54BC,
++  0x54D8,
++  0x54E5,
++  0x54E6,
++  0x550F,
++  0x5514,
++  0x54FD,
++  0x54EE,
++  0x54ED,
++  0x54FA,
++  0x54E2,
++  0x5539,
++  0x5540,
++  0x5563,
++  0x554C,
++  0x552E,
++  0x555C,
++  0x5545,
++  0x5556,
++  0x5557,
++  0x5538,
++  0x5533,
++  0x555D,
++  0x5599,
++  0x5580,
++  0x54AF,
++  0x558A,
++  0x559F,
++  0x557B,
++  0x557E,
++  0x5598,
++  0x559E,
++  0x55AE,
++  0x557C,
++  0x5583,
++  0x55A9,
++  0x5587,
++  0x55A8,
++  0x55DA,
++  0x55C5,
++  0x55DF,
++  0x55C4,
++  0x55DC,
++  0x55E4,
++  0x55D4,
++  0x5614,
++  0x55F7,
++  0x5616,
++  0x55FE,
++  0x55FD,
++  0x561B,
++  0x55F9,
++  0x564E,
++  0x5650,
++  0x71DF,
++  0x5634,
++  0x5636,
++  0x5632,
++  0x5638,
++  0x566B,
++  0x5664,
++  0x562F,
++  0x566C,
++  0x566A,
++  0x5686,
++  0x5680,
++  0x568A,
++  0x56A0,
++  0x5694,
++  0x568F,
++  0x56A5,
++  0x56AE,
++  0x56B6,
++  0x56B4,
++  0x56C2,
++  0x56BC,
++  0x56C1,
++  0x56C3,
++  0x56C0,
++  0x56C8,
++  0x56CE,
++  0x56D1,
++  0x56D3,
++  0x56D7,
++  0x56EE,
++  0x56F9,
++  0x5700,
++  0x56FF,
++  0x5704,
++  0x5709,
++  0x5708,
++  0x570B,
++  0x570D,
++  0x5713,
++  0x5718,
++  0x5716,
++  0x55C7,
++  0x571C,
++  0x5726,
++  0x5737,
++  0x5738,
++  0x574E,
++  0x573B,
++  0x5740,
++  0x574F,
++  0x5769,
++  0x57C0,
++  0x5788,
++  0x5761,
++  0x577F,
++  0x5789,
++  0x5793,
++  0x57A0,
++  0x57B3,
++  0x57A4,
++  0x57AA,
++  0x57B0,
++  0x57C3,
++  0x57C6,
++  0x57D4,
++  0x57D2,
++  0x57D3,
++  0x580A,
++  0x57D6,
++  0x57E3,
++  0x580B,
++  0x5819,
++  0x581D,
++  0x5872,
++  0x5821,
++  0x5862,
++  0x584B,
++  0x5870,
++  0x6BC0,
++  0x5852,
++  0x583D,
++  0x5879,
++  0x5885,
++  0x58B9,
++  0x589F,
++  0x58AB,
++  0x58BA,
++  0x58DE,
++  0x58BB,
++  0x58B8,
++  0x58AE,
++  0x58C5,
++  0x58D3,
++  0x58D1,
++  0x58D7,
++  0x58D9,
++  0x58D8,
++  0x58E5,
++  0x58DC,
++  0x58E4,
++  0x58DF,
++  0x58EF,
++  0x58FA,
++  0x58F9,
++  0x58FB,
++  0x58FC,
++  0x58FD,
++  0x5902,
++  0x590A,
++  0x5910,
++  0x591B,
++  0x68A6,
++  0x5925,
++  0x592C,
++  0x592D,
++  0x5932,
++  0x5938,
++  0x593E,
++  0x7AD2,
++  0x5955,
++  0x5950,
++  0x594E,
++  0x595A,
++  0x5958,
++  0x5962,
++  0x5960,
++  0x5967,
++  0x596C,
++  0x5969,
++  0x5978,
++  0x5981,
++  0x599D,
++  0x4F5E,
++  0x4FAB,
++  0x59A3,
++  0x59B2,
++  0x59C6,
++  0x59E8,
++  0x59DC,
++  0x598D,
++  0x59D9,
++  0x59DA,
++  0x5A25,
++  0x5A1F,
++  0x5A11,
++  0x5A1C,
++  0x5A09,
++  0x5A1A,
++  0x5A40,
++  0x5A6C,
++  0x5A49,
++  0x5A35,
++  0x5A36,
++  0x5A62,
++  0x5A6A,
++  0x5A9A,
++  0x5ABC,
++  0x5ABE,
++  0x5ACB,
++  0x5AC2,
++  0x5ABD,
++  0x5AE3,
++  0x5AD7,
++  0x5AE6,
++  0x5AE9,
++  0x5AD6,
++  0x5AFA,
++  0x5AFB,
++  0x5B0C,
++  0x5B0B,
++  0x5B16,
++  0x5B32,
++  0x5AD0,
++  0x5B2A,
++  0x5B36,
++  0x5B3E,
++  0x5B43,
++  0x5B45,
++  0x5B40,
++  0x5B51,
++  0x5B55,
++  0x5B5A,
++  0x5B5B,
++  0x5B65,
++  0x5B69,
++  0x5B70,
++  0x5B73,
++  0x5B75,
++  0x5B78,
++  0x6588,
++  0x5B7A,
++  0x5B80,
++  0x5B83,
++  0x5BA6,
++  0x5BB8,
++  0x5BC3,
++  0x5BC7,
++  0x5BC9,
++  0x5BD4,
++  0x5BD0,
++  0x5BE4,
++  0x5BE6,
++  0x5BE2,
++  0x5BDE,
++  0x5BE5,
++  0x5BEB,
++  0x5BF0,
++  0x5BF6,
++  0x5BF3,
++  0x5C05,
++  0x5C07,
++  0x5C08,
++  0x5C0D,
++  0x5C13,
++  0x5C20,
++  0x5C22,
++  0x5C28,
++  0x5C38,
++  0x5C39,
++  0x5C41,
++  0x5C46,
++  0x5C4E,
++  0x5C53,
++  0x5C50,
++  0x5C4F,
++  0x5B71,
++  0x5C6C,
++  0x5C6E,
++  0x4E62,
++  0x5C76,
++  0x5C79,
++  0x5C8C,
++  0x5C91,
++  0x5C94,
++  0x599B,
++  0x5CAB,
++  0x5CBB,
++  0x5CB6,
++  0x5CBC,
++  0x5CB7,
++  0x5CC5,
++  0x5CBE,
++  0x5CC7,
++  0x5CD9,
++  0x5CE9,
++  0x5CFD,
++  0x5CFA,
++  0x5CED,
++  0x5D8C,
++  0x5CEA,
++  0x5D0B,
++  0x5D15,
++  0x5D17,
++  0x5D5C,
++  0x5D1F,
++  0x5D1B,
++  0x5D11,
++  0x5D14,
++  0x5D22,
++  0x5D1A,
++  0x5D19,
++  0x5D18,
++  0x5D4C,
++  0x5D52,
++  0x5D4E,
++  0x5D4B,
++  0x5D6C,
++  0x5D73,
++  0x5D76,
++  0x5D87,
++  0x5D84,
++  0x5D82,
++  0x5DA2,
++  0x5D9D,
++  0x5DAC,
++  0x5DAE,
++  0x5DBD,
++  0x5D90,
++  0x5DB7,
++  0x5DBC,
++  0x5DC9,
++  0x5DCD,
++  0x5DD3,
++  0x5DD2,
++  0x5DD6,
++  0x5DDB,
++  0x5DEB,
++  0x5DF2,
++  0x5DF5,
++  0x5E0B,
++  0x5E1A,
++  0x5E19,
++  0x5E11,
++  0x5E1B,
++  0x5E36,
++  0x5E37,
++  0x5E44,
++  0x5E43,
++  0x5E40,
++  0x5E4E,
++  0x5E57,
++  0x5E54,
++  0x5E5F,
++  0x5E62,
++  0x5E64,
++  0x5E47,
++  0x5E75,
++  0x5E76,
++  0x5E7A,
++  0x9EBC,
++  0x5E7F,
++  0x5EA0,
++  0x5EC1,
++  0x5EC2,
++  0x5EC8,
++  0x5ED0,
++  0x5ECF,
++  0x5ED6,
++  0x5EE3,
++  0x5EDD,
++  0x5EDA,
++  0x5EDB,
++  0x5EE2,
++  0x5EE1,
++  0x5EE8,
++  0x5EE9,
++  0x5EEC,
++  0x5EF1,
++  0x5EF3,
++  0x5EF0,
++  0x5EF4,
++  0x5EF8,
++  0x5EFE,
++  0x5F03,
++  0x5F09,
++  0x5F5D,
++  0x5F5C,
++  0x5F0B,
++  0x5F11,
++  0x5F16,
++  0x5F29,
++  0x5F2D,
++  0x5F38,
++  0x5F41,
++  0x5F48,
++  0x5F4C,
++  0x5F4E,
++  0x5F2F,
++  0x5F51,
++  0x5F56,
++  0x5F57,
++  0x5F59,
++  0x5F61,
++  0x5F6D,
++  0x5F73,
++  0x5F77,
++  0x5F83,
++  0x5F82,
++  0x5F7F,
++  0x5F8A,
++  0x5F88,
++  0x5F91,
++  0x5F87,
++  0x5F9E,
++  0x5F99,
++  0x5F98,
++  0x5FA0,
++  0x5FA8,
++  0x5FAD,
++  0x5FBC,
++  0x5FD6,
++  0x5FFB,
++  0x5FE4,
++  0x5FF8,
++  0x5FF1,
++  0x5FDD,
++  0x60B3,
++  0x5FFF,
++  0x6021,
++  0x6060,
++  0x6019,
++  0x6010,
++  0x6029,
++  0x600E,
++  0x6031,
++  0x601B,
++  0x6015,
++  0x602B,
++  0x6026,
++  0x600F,
++  0x603A,
++  0x605A,
++  0x6041,
++  0x606A,
++  0x6077,
++  0x605F,
++  0x604A,
++  0x6046,
++  0x604D,
++  0x6063,
++  0x6043,
++  0x6064,
++  0x6042,
++  0x606C,
++  0x606B,
++  0x6059,
++  0x6081,
++  0x608D,
++  0x60E7,
++  0x6083,
++  0x609A,
++  0x6084,
++  0x609B,
++  0x6096,
++  0x6097,
++  0x6092,
++  0x60A7,
++  0x608B,
++  0x60E1,
++  0x60B8,
++  0x60E0,
++  0x60D3,
++  0x60B4,
++  0x5FF0,
++  0x60BD,
++  0x60C6,
++  0x60B5,
++  0x60D8,
++  0x614D,
++  0x6115,
++  0x6106,
++  0x60F6,
++  0x60F7,
++  0x6100,
++  0x60F4,
++  0x60FA,
++  0x6103,
++  0x6121,
++  0x60FB,
++  0x60F1,
++  0x610D,
++  0x610E,
++  0x6147,
++  0x613E,
++  0x6128,
++  0x6127,
++  0x614A,
++  0x613F,
++  0x613C,
++  0x612C,
++  0x6134,
++  0x613D,
++  0x6142,
++  0x6144,
++  0x6173,
++  0x6177,
++  0x6158,
++  0x6159,
++  0x615A,
++  0x616B,
++  0x6174,
++  0x616F,
++  0x6165,
++  0x6171,
++  0x615F,
++  0x615D,
++  0x6153,
++  0x6175,
++  0x6199,
++  0x6196,
++  0x6187,
++  0x61AC,
++  0x6194,
++  0x619A,
++  0x618A,
++  0x6191,
++  0x61AB,
++  0x61AE,
++  0x61CC,
++  0x61CA,
++  0x61C9,
++  0x61F7,
++  0x61C8,
++  0x61C3,
++  0x61C6,
++  0x61BA,
++  0x61CB,
++  0x7F79,
++  0x61CD,
++  0x61E6,
++  0x61E3,
++  0x61F6,
++  0x61FA,
++  0x61F4,
++  0x61FF,
++  0x61FD,
++  0x61FC,
++  0x61FE,
++  0x6200,
++  0x6208,
++  0x6209,
++  0x620D,
++  0x620C,
++  0x6214,
++  0x621B,
++  0x621E,
++  0x6221,
++  0x622A,
++  0x622E,
++  0x6230,
++  0x6232,
++  0x6233,
++  0x6241,
++  0x624E,
++  0x625E,
++  0x6263,
++  0x625B,
++  0x6260,
++  0x6268,
++  0x627C,
++  0x6282,
++  0x6289,
++  0x627E,
++  0x6292,
++  0x6293,
++  0x6296,
++  0x62D4,
++  0x6283,
++  0x6294,
++  0x62D7,
++  0x62D1,
++  0x62BB,
++  0x62CF,
++  0x62FF,
++  0x62C6,
++  0x64D4,
++  0x62C8,
++  0x62DC,
++  0x62CC,
++  0x62CA,
++  0x62C2,
++  0x62C7,
++  0x629B,
++  0x62C9,
++  0x630C,
++  0x62EE,
++  0x62F1,
++  0x6327,
++  0x6302,
++  0x6308,
++  0x62EF,
++  0x62F5,
++  0x6350,
++  0x633E,
++  0x634D,
++  0x641C,
++  0x634F,
++  0x6396,
++  0x638E,
++  0x6380,
++  0x63AB,
++  0x6376,
++  0x63A3,
++  0x638F,
++  0x6389,
++  0x639F,
++  0x63B5,
++  0x636B,
++  0x6369,
++  0x63BE,
++  0x63E9,
++  0x63C0,
++  0x63C6,
++  0x63E3,
++  0x63C9,
++  0x63D2,
++  0x63F6,
++  0x63C4,
++  0x6416,
++  0x6434,
++  0x6406,
++  0x6413,
++  0x6426,
++  0x6436,
++  0x651D,
++  0x6417,
++  0x6428,
++  0x640F,
++  0x6467,
++  0x646F,
++  0x6476,
++  0x644E,
++  0x652A,
++  0x6495,
++  0x6493,
++  0x64A5,
++  0x64A9,
++  0x6488,
++  0x64BC,
++  0x64DA,
++  0x64D2,
++  0x64C5,
++  0x64C7,
++  0x64BB,
++  0x64D8,
++  0x64C2,
++  0x64F1,
++  0x64E7,
++  0x8209,
++  0x64E0,
++  0x64E1,
++  0x62AC,
++  0x64E3,
++  0x64EF,
++  0x652C,
++  0x64F6,
++  0x64F4,
++  0x64F2,
++  0x64FA,
++  0x6500,
++  0x64FD,
++  0x6518,
++  0x651C,
++  0x6505,
++  0x6524,
++  0x6523,
++  0x652B,
++  0x6534,
++  0x6535,
++  0x6537,
++  0x6536,
++  0x6538,
++  0x754B,
++  0x6548,
++  0x6556,
++  0x6555,
++  0x654D,
++  0x6558,
++  0x655E,
++  0x655D,
++  0x6572,
++  0x6578,
++  0x6582,
++  0x6583,
++  0x8B8A,
++  0x659B,
++  0x659F,
++  0x65AB,
++  0x65B7,
++  0x65C3,
++  0x65C6,
++  0x65C1,
++  0x65C4,
++  0x65CC,
++  0x65D2,
++  0x65DB,
++  0x65D9,
++  0x65E0,
++  0x65E1,
++  0x65F1,
++  0x6772,
++  0x660A,
++  0x6603,
++  0x65FB,
++  0x6773,
++  0x6635,
++  0x6636,
++  0x6634,
++  0x661C,
++  0x664F,
++  0x6644,
++  0x6649,
++  0x6641,
++  0x665E,
++  0x665D,
++  0x6664,
++  0x6667,
++  0x6668,
++  0x665F,
++  0x6662,
++  0x6670,
++  0x6683,
++  0x6688,
++  0x668E,
++  0x6689,
++  0x6684,
++  0x6698,
++  0x669D,
++  0x66C1,
++  0x66B9,
++  0x66C9,
++  0x66BE,
++  0x66BC,
++  0x66C4,
++  0x66B8,
++  0x66D6,
++  0x66DA,
++  0x66E0,
++  0x663F,
++  0x66E6,
++  0x66E9,
++  0x66F0,
++  0x66F5,
++  0x66F7,
++  0x670F,
++  0x6716,
++  0x671E,
++  0x6726,
++  0x6727,
++  0x9738,
++  0x672E,
++  0x673F,
++  0x6736,
++  0x6741,
++  0x6738,
++  0x6737,
++  0x6746,
++  0x675E,
++  0x6760,
++  0x6759,
++  0x6763,
++  0x6764,
++  0x6789,
++  0x6770,
++  0x67A9,
++  0x677C,
++  0x676A,
++  0x678C,
++  0x678B,
++  0x67A6,
++  0x67A1,
++  0x6785,
++  0x67B7,
++  0x67EF,
++  0x67B4,
++  0x67EC,
++  0x67B3,
++  0x67E9,
++  0x67B8,
++  0x67E4,
++  0x67DE,
++  0x67DD,
++  0x67E2,
++  0x67EE,
++  0x67B9,
++  0x67CE,
++  0x67C6,
++  0x67E7,
++  0x6A9C,
++  0x681E,
++  0x6846,
++  0x6829,
++  0x6840,
++  0x684D,
++  0x6832,
++  0x684E,
++  0x68B3,
++  0x682B,
++  0x6859,
++  0x6863,
++  0x6877,
++  0x687F,
++  0x689F,
++  0x688F,
++  0x68AD,
++  0x6894,
++  0x689D,
++  0x689B,
++  0x6883,
++  0x6AAE,
++  0x68B9,
++  0x6874,
++  0x68B5,
++  0x68A0,
++  0x68BA,
++  0x690F,
++  0x688D,
++  0x687E,
++  0x6901,
++  0x68CA,
++  0x6908,
++  0x68D8,
++  0x6922,
++  0x6926,
++  0x68E1,
++  0x690C,
++  0x68CD,
++  0x68D4,
++  0x68E7,
++  0x68D5,
++  0x6936,
++  0x6912,
++  0x6904,
++  0x68D7,
++  0x68E3,
++  0x6925,
++  0x68F9,
++  0x68E0,
++  0x68EF,
++  0x6928,
++  0x692A,
++  0x691A,
++  0x6923,
++  0x6921,
++  0x68C6,
++  0x6979,
++  0x6977,
++  0x695C,
++  0x6978,
++  0x696B,
++  0x6954,
++  0x697E,
++  0x696E,
++  0x6939,
++  0x6974,
++  0x693D,
++  0x6959,
++  0x6930,
++  0x6961,
++  0x695E,
++  0x695D,
++  0x6981,
++  0x696A,
++  0x69B2,
++  0x69AE,
++  0x69D0,
++  0x69BF,
++  0x69C1,
++  0x69D3,
++  0x69BE,
++  0x69CE,
++  0x5BE8,
++  0x69CA,
++  0x69DD,
++  0x69BB,
++  0x69C3,
++  0x69A7,
++  0x6A2E,
++  0x6991,
++  0x69A0,
++  0x699C,
++  0x6995,
++  0x69B4,
++  0x69DE,
++  0x69E8,
++  0x6A02,
++  0x6A1B,
++  0x69FF,
++  0x6B0A,
++  0x69F9,
++  0x69F2,
++  0x69E7,
++  0x6A05,
++  0x69B1,
++  0x6A1E,
++  0x69ED,
++  0x6A14,
++  0x69EB,
++  0x6A0A,
++  0x6A12,
++  0x6AC1,
++  0x6A23,
++  0x6A13,
++  0x6A44,
++  0x6A0C,
++  0x6A72,
++  0x6A36,
++  0x6A78,
++  0x6A47,
++  0x6A62,
++  0x6A59,
++  0x6A66,
++  0x6A48,
++  0x6A38,
++  0x6A22,
++  0x6A90,
++  0x6A8D,
++  0x6AA0,
++  0x6A84,
++  0x6AA2,
++  0x6AA3,
++  0x6A97,
++  0x8617,
++  0x6ABB,
++  0x6AC3,
++  0x6AC2,
++  0x6AB8,
++  0x6AB3,
++  0x6AAC,
++  0x6ADE,
++  0x6AD1,
++  0x6ADF,
++  0x6AAA,
++  0x6ADA,
++  0x6AEA,
++  0x6AFB,
++  0x6B05,
++  0x8616,
++  0x6AFA,
++  0x6B12,
++  0x6B16,
++  0x9B31,
++  0x6B1F,
++  0x6B38,
++  0x6B37,
++  0x76DC,
++  0x6B39,
++  0x98EE,
++  0x6B47,
++  0x6B43,
++  0x6B49,
++  0x6B50,
++  0x6B59,
++  0x6B54,
++  0x6B5B,
++  0x6B5F,
++  0x6B61,
++  0x6B78,
++  0x6B79,
++  0x6B7F,
++  0x6B80,
++  0x6B84,
++  0x6B83,
++  0x6B8D,
++  0x6B98,
++  0x6B95,
++  0x6B9E,
++  0x6BA4,
++  0x6BAA,
++  0x6BAB,
++  0x6BAF,
++  0x6BB2,
++  0x6BB1,
++  0x6BB3,
++  0x6BB7,
++  0x6BBC,
++  0x6BC6,
++  0x6BCB,
++  0x6BD3,
++  0x6BDF,
++  0x6BEC,
++  0x6BEB,
++  0x6BF3,
++  0x6BEF,
++  0x9EBE,
++  0x6C08,
++  0x6C13,
++  0x6C14,
++  0x6C1B,
++  0x6C24,
++  0x6C23,
++  0x6C5E,
++  0x6C55,
++  0x6C62,
++  0x6C6A,
++  0x6C82,
++  0x6C8D,
++  0x6C9A,
++  0x6C81,
++  0x6C9B,
++  0x6C7E,
++  0x6C68,
++  0x6C73,
++  0x6C92,
++  0x6C90,
++  0x6CC4,
++  0x6CF1,
++  0x6CD3,
++  0x6CBD,
++  0x6CD7,
++  0x6CC5,
++  0x6CDD,
++  0x6CAE,
++  0x6CB1,
++  0x6CBE,
++  0x6CBA,
++  0x6CDB,
++  0x6CEF,
++  0x6CD9,
++  0x6CEA,
++  0x6D1F,
++  0x884D,
++  0x6D36,
++  0x6D2B,
++  0x6D3D,
++  0x6D38,
++  0x6D19,
++  0x6D35,
++  0x6D33,
++  0x6D12,
++  0x6D0C,
++  0x6D63,
++  0x6D93,
++  0x6D64,
++  0x6D5A,
++  0x6D79,
++  0x6D59,
++  0x6D8E,
++  0x6D95,
++  0x6FE4,
++  0x6D85,
++  0x6DF9,
++  0x6E15,
++  0x6E0A,
++  0x6DB5,
++  0x6DC7,
++  0x6DE6,
++  0x6DB8,
++  0x6DC6,
++  0x6DEC,
++  0x6DDE,
++  0x6DCC,
++  0x6DE8,
++  0x6DD2,
++  0x6DC5,
++  0x6DFA,
++  0x6DD9,
++  0x6DE4,
++  0x6DD5,
++  0x6DEA,
++  0x6DEE,
++  0x6E2D,
++  0x6E6E,
++  0x6E2E,
++  0x6E19,
++  0x6E72,
++  0x6E5F,
++  0x6E3E,
++  0x6E23,
++  0x6E6B,
++  0x6E2B,
++  0x6E76,
++  0x6E4D,
++  0x6E1F,
++  0x6E43,
++  0x6E3A,
++  0x6E4E,
++  0x6E24,
++  0x6EFF,
++  0x6E1D,
++  0x6E38,
++  0x6E82,
++  0x6EAA,
++  0x6E98,
++  0x6EC9,
++  0x6EB7,
++  0x6ED3,
++  0x6EBD,
++  0x6EAF,
++  0x6EC4,
++  0x6EB2,
++  0x6ED4,
++  0x6ED5,
++  0x6E8F,
++  0x6EA5,
++  0x6EC2,
++  0x6E9F,
++  0x6F41,
++  0x6F11,
++  0x704C,
++  0x6EEC,
++  0x6EF8,
++  0x6EFE,
++  0x6F3F,
++  0x6EF2,
++  0x6F31,
++  0x6EEF,
++  0x6F32,
++  0x6ECC,
++  0x6F3E,
++  0x6F13,
++  0x6EF7,
++  0x6F86,
++  0x6F7A,
++  0x6F78,
++  0x6F81,
++  0x6F80,
++  0x6F6F,
++  0x6F5B,
++  0x6FF3,
++  0x6F6D,
++  0x6F82,
++  0x6F7C,
++  0x6F58,
++  0x6F8E,
++  0x6F91,
++  0x6FC2,
++  0x6F66,
++  0x6FB3,
++  0x6FA3,
++  0x6FA1,
++  0x6FA4,
++  0x6FB9,
++  0x6FC6,
++  0x6FAA,
++  0x6FDF,
++  0x6FD5,
++  0x6FEC,
++  0x6FD4,
++  0x6FD8,
++  0x6FF1,
++  0x6FEE,
++  0x6FDB,
++  0x7009,
++  0x700B,
++  0x6FFA,
++  0x7011,
++  0x7001,
++  0x700F,
++  0x6FFE,
++  0x701B,
++  0x701A,
++  0x6F74,
++  0x701D,
++  0x7018,
++  0x701F,
++  0x7030,
++  0x703E,
++  0x7032,
++  0x7051,
++  0x7063,
++  0x7099,
++  0x7092,
++  0x70AF,
++  0x70F1,
++  0x70AC,
++  0x70B8,
++  0x70B3,
++  0x70AE,
++  0x70DF,
++  0x70CB,
++  0x70DD,
++  0x70D9,
++  0x7109,
++  0x70FD,
++  0x711C,
++  0x7119,
++  0x7165,
++  0x7155,
++  0x7188,
++  0x7166,
++  0x7162,
++  0x714C,
++  0x7156,
++  0x716C,
++  0x718F,
++  0x71FB,
++  0x7184,
++  0x7195,
++  0x71A8,
++  0x71AC,
++  0x71D7,
++  0x71B9,
++  0x71BE,
++  0x71D2,
++  0x71C9,
++  0x71D4,
++  0x71CE,
++  0x71E0,
++  0x71EC,
++  0x71E7,
++  0x71F5,
++  0x71FC,
++  0x71F9,
++  0x71FF,
++  0x720D,
++  0x7210,
++  0x721B,
++  0x7228,
++  0x722D,
++  0x722C,
++  0x7230,
++  0x7232,
++  0x723B,
++  0x723C,
++  0x723F,
++  0x7240,
++  0x7246,
++  0x724B,
++  0x7258,
++  0x7274,
++  0x727E,
++  0x7282,
++  0x7281,
++  0x7287,
++  0x7292,
++  0x7296,
++  0x72A2,
++  0x72A7,
++  0x72B9,
++  0x72B2,
++  0x72C3,
++  0x72C6,
++  0x72C4,
++  0x72CE,
++  0x72D2,
++  0x72E2,
++  0x72E0,
++  0x72E1,
++  0x72F9,
++  0x72F7,
++  0x500F,
++  0x7317,
++  0x730A,
++  0x731C,
++  0x7316,
++  0x731D,
++  0x7334,
++  0x732F,
++  0x7329,
++  0x7325,
++  0x733E,
++  0x734E,
++  0x734F,
++  0x9ED8,
++  0x7357,
++  0x736A,
++  0x7368,
++  0x7370,
++  0x7378,
++  0x7375,
++  0x737B,
++  0x737A,
++  0x73C8,
++  0x73B3,
++  0x73CE,
++  0x73BB,
++  0x73C0,
++  0x73E5,
++  0x73EE,
++  0x73DE,
++  0x74A2,
++  0x7405,
++  0x746F,
++  0x7425,
++  0x73F8,
++  0x7432,
++  0x743A,
++  0x7455,
++  0x743F,
++  0x745F,
++  0x7459,
++  0x7441,
++  0x745C,
++  0x7469,
++  0x7470,
++  0x7463,
++  0x746A,
++  0x7476,
++  0x747E,
++  0x748B,
++  0x749E,
++  0x74A7,
++  0x74CA,
++  0x74CF,
++  0x74D4,
++  0x73F1,
++  0x74E0,
++  0x74E3,
++  0x74E7,
++  0x74E9,
++  0x74EE,
++  0x74F2,
++  0x74F0,
++  0x74F1,
++  0x74F8,
++  0x74F7,
++  0x7504,
++  0x7503,
++  0x7505,
++  0x750C,
++  0x750E,
++  0x750D,
++  0x7515,
++  0x7513,
++  0x751E,
++  0x7526,
++  0x752C,
++  0x753C,
++  0x7544,
++  0x754D,
++  0x754A,
++  0x7549,
++  0x755B,
++  0x7546,
++  0x755A,
++  0x7569,
++  0x7564,
++  0x7567,
++  0x756B,
++  0x756D,
++  0x7578,
++  0x7576,
++  0x7586,
++  0x7587,
++  0x7574,
++  0x758A,
++  0x7589,
++  0x7582,
++  0x7594,
++  0x759A,
++  0x759D,
++  0x75A5,
++  0x75A3,
++  0x75C2,
++  0x75B3,
++  0x75C3,
++  0x75B5,
++  0x75BD,
++  0x75B8,
++  0x75BC,
++  0x75B1,
++  0x75CD,
++  0x75CA,
++  0x75D2,
++  0x75D9,
++  0x75E3,
++  0x75DE,
++  0x75FE,
++  0x75FF,
++  0x75FC,
++  0x7601,
++  0x75F0,
++  0x75FA,
++  0x75F2,
++  0x75F3,
++  0x760B,
++  0x760D,
++  0x7609,
++  0x761F,
++  0x7627,
++  0x7620,
++  0x7621,
++  0x7622,
++  0x7624,
++  0x7634,
++  0x7630,
++  0x763B,
++  0x7647,
++  0x7648,
++  0x7646,
++  0x765C,
++  0x7658,
++  0x7661,
++  0x7662,
++  0x7668,
++  0x7669,
++  0x766A,
++  0x7667,
++  0x766C,
++  0x7670,
++  0x7672,
++  0x7676,
++  0x7678,
++  0x767C,
++  0x7680,
++  0x7683,
++  0x7688,
++  0x768B,
++  0x768E,
++  0x7696,
++  0x7693,
++  0x7699,
++  0x769A,
++  0x76B0,
++  0x76B4,
++  0x76B8,
++  0x76B9,
++  0x76BA,
++  0x76C2,
++  0x76CD,
++  0x76D6,
++  0x76D2,
++  0x76DE,
++  0x76E1,
++  0x76E5,
++  0x76E7,
++  0x76EA,
++  0x862F,
++  0x76FB,
++  0x7708,
++  0x7707,
++  0x7704,
++  0x7729,
++  0x7724,
++  0x771E,
++  0x7725,
++  0x7726,
++  0x771B,
++  0x7737,
++  0x7738,
++  0x7747,
++  0x775A,
++  0x7768,
++  0x776B,
++  0x775B,
++  0x7765,
++  0x777F,
++  0x777E,
++  0x7779,
++  0x778E,
++  0x778B,
++  0x7791,
++  0x77A0,
++  0x779E,
++  0x77B0,
++  0x77B6,
++  0x77B9,
++  0x77BF,
++  0x77BC,
++  0x77BD,
++  0x77BB,
++  0x77C7,
++  0x77CD,
++  0x77D7,
++  0x77DA,
++  0x77DC,
++  0x77E3,
++  0x77EE,
++  0x77FC,
++  0x780C,
++  0x7812,
++  0x7926,
++  0x7820,
++  0x792A,
++  0x7845,
++  0x788E,
++  0x7874,
++  0x7886,
++  0x787C,
++  0x789A,
++  0x788C,
++  0x78A3,
++  0x78B5,
++  0x78AA,
++  0x78AF,
++  0x78D1,
++  0x78C6,
++  0x78CB,
++  0x78D4,
++  0x78BE,
++  0x78BC,
++  0x78C5,
++  0x78CA,
++  0x78EC,
++  0x78E7,
++  0x78DA,
++  0x78FD,
++  0x78F4,
++  0x7907,
++  0x7912,
++  0x7911,
++  0x7919,
++  0x792C,
++  0x792B,
++  0x7940,
++  0x7960,
++  0x7957,
++  0x795F,
++  0x795A,
++  0x7955,
++  0x7953,
++  0x797A,
++  0x797F,
++  0x798A,
++  0x799D,
++  0x79A7,
++  0x9F4B,
++  0x79AA,
++  0x79AE,
++  0x79B3,
++  0x79B9,
++  0x79BA,
++  0x79C9,
++  0x79D5,
++  0x79E7,
++  0x79EC,
++  0x79E1,
++  0x79E3,
++  0x7A08,
++  0x7A0D,
++  0x7A18,
++  0x7A19,
++  0x7A20,
++  0x7A1F,
++  0x7980,
++  0x7A31,
++  0x7A3B,
++  0x7A3E,
++  0x7A37,
++  0x7A43,
++  0x7A57,
++  0x7A49,
++  0x7A61,
++  0x7A62,
++  0x7A69,
++  0x9F9D,
++  0x7A70,
++  0x7A79,
++  0x7A7D,
++  0x7A88,
++  0x7A97,
++  0x7A95,
++  0x7A98,
++  0x7A96,
++  0x7AA9,
++  0x7AC8,
++  0x7AB0,
++  0x7AB6,
++  0x7AC5,
++  0x7AC4,
++  0x7ABF,
++  0x9083,
++  0x7AC7,
++  0x7ACA,
++  0x7ACD,
++  0x7ACF,
++  0x7AD5,
++  0x7AD3,
++  0x7AD9,
++  0x7ADA,
++  0x7ADD,
++  0x7AE1,
++  0x7AE2,
++  0x7AE6,
++  0x7AED,
++  0x7AF0,
++  0x7B02,
++  0x7B0F,
++  0x7B0A,
++  0x7B06,
++  0x7B33,
++  0x7B18,
++  0x7B19,
++  0x7B1E,
++  0x7B35,
++  0x7B28,
++  0x7B36,
++  0x7B50,
++  0x7B7A,
++  0x7B04,
++  0x7B4D,
++  0x7B0B,
++  0x7B4C,
++  0x7B45,
++  0x7B75,
++  0x7B65,
++  0x7B74,
++  0x7B67,
++  0x7B70,
++  0x7B71,
++  0x7B6C,
++  0x7B6E,
++  0x7B9D,
++  0x7B98,
++  0x7B9F,
++  0x7B8D,
++  0x7B9C,
++  0x7B9A,
++  0x7B8B,
++  0x7B92,
++  0x7B8F,
++  0x7B5D,
++  0x7B99,
++  0x7BCB,
++  0x7BC1,
++  0x7BCC,
++  0x7BCF,
++  0x7BB4,
++  0x7BC6,
++  0x7BDD,
++  0x7BE9,
++  0x7C11,
++  0x7C14,
++  0x7BE6,
++  0x7BE5,
++  0x7C60,
++  0x7C00,
++  0x7C07,
++  0x7C13,
++  0x7BF3,
++  0x7BF7,
++  0x7C17,
++  0x7C0D,
++  0x7BF6,
++  0x7C23,
++  0x7C27,
++  0x7C2A,
++  0x7C1F,
++  0x7C37,
++  0x7C2B,
++  0x7C3D,
++  0x7C4C,
++  0x7C43,
++  0x7C54,
++  0x7C4F,
++  0x7C40,
++  0x7C50,
++  0x7C58,
++  0x7C5F,
++  0x7C64,
++  0x7C56,
++  0x7C65,
++  0x7C6C,
++  0x7C75,
++  0x7C83,
++  0x7C90,
++  0x7CA4,
++  0x7CAD,
++  0x7CA2,
++  0x7CAB,
++  0x7CA1,
++  0x7CA8,
++  0x7CB3,
++  0x7CB2,
++  0x7CB1,
++  0x7CAE,
++  0x7CB9,
++  0x7CBD,
++  0x7CC0,
++  0x7CC5,
++  0x7CC2,
++  0x7CD8,
++  0x7CD2,
++  0x7CDC,
++  0x7CE2,
++  0x9B3B,
++  0x7CEF,
++  0x7CF2,
++  0x7CF4,
++  0x7CF6,
++  0x7CFA,
++  0x7D06,
++  0x7D02,
++  0x7D1C,
++  0x7D15,
++  0x7D0A,
++  0x7D45,
++  0x7D4B,
++  0x7D2E,
++  0x7D32,
++  0x7D3F,
++  0x7D35,
++  0x7D46,
++  0x7D73,
++  0x7D56,
++  0x7D4E,
++  0x7D72,
++  0x7D68,
++  0x7D6E,
++  0x7D4F,
++  0x7D63,
++  0x7D93,
++  0x7D89,
++  0x7D5B,
++  0x7D8F,
++  0x7D7D,
++  0x7D9B,
++  0x7DBA,
++  0x7DAE,
++  0x7DA3,
++  0x7DB5,
++  0x7DC7,
++  0x7DBD,
++  0x7DAB,
++  0x7E3D,
++  0x7DA2,
++  0x7DAF,
++  0x7DDC,
++  0x7DB8,
++  0x7D9F,
++  0x7DB0,
++  0x7DD8,
++  0x7DDD,
++  0x7DE4,
++  0x7DDE,
++  0x7DFB,
++  0x7DF2,
++  0x7DE1,
++  0x7E05,
++  0x7E0A,
++  0x7E23,
++  0x7E21,
++  0x7E12,
++  0x7E31,
++  0x7E1F,
++  0x7E09,
++  0x7E0B,
++  0x7E22,
++  0x7E46,
++  0x7E66,
++  0x7E3B,
++  0x7E35,
++  0x7E39,
++  0x7E43,
++  0x7E37,
++  0x7E32,
++  0x7E3A,
++  0x7E67,
++  0x7E5D,
++  0x7E56,
++  0x7E5E,
++  0x7E59,
++  0x7E5A,
++  0x7E79,
++  0x7E6A,
++  0x7E69,
++  0x7E7C,
++  0x7E7B,
++  0x7E83,
++  0x7DD5,
++  0x7E7D,
++  0x8FAE,
++  0x7E7F,
++  0x7E88,
++  0x7E89,
++  0x7E8C,
++  0x7E92,
++  0x7E90,
++  0x7E93,
++  0x7E94,
++  0x7E96,
++  0x7E8E,
++  0x7E9B,
++  0x7E9C,
++  0x7F38,
++  0x7F3A,
++  0x7F45,
++  0x7F4C,
++  0x7F4D,
++  0x7F4E,
++  0x7F50,
++  0x7F51,
++  0x7F55,
++  0x7F54,
++  0x7F58,
++  0x7F5F,
++  0x7F60,
++  0x7F68,
++  0x7F69,
++  0x7F67,
++  0x7F78,
++  0x7F82,
++  0x7F86,
++  0x7F83,
++  0x7F88,
++  0x7F87,
++  0x7F8C,
++  0x7F94,
++  0x7F9E,
++  0x7F9D,
++  0x7F9A,
++  0x7FA3,
++  0x7FAF,
++  0x7FB2,
++  0x7FB9,
++  0x7FAE,
++  0x7FB6,
++  0x7FB8,
++  0x8B71,
++  0x7FC5,
++  0x7FC6,
++  0x7FCA,
++  0x7FD5,
++  0x7FD4,
++  0x7FE1,
++  0x7FE6,
++  0x7FE9,
++  0x7FF3,
++  0x7FF9,
++  0x98DC,
++  0x8006,
++  0x8004,
++  0x800B,
++  0x8012,
++  0x8018,
++  0x8019,
++  0x801C,
++  0x8021,
++  0x8028,
++  0x803F,
++  0x803B,
++  0x804A,
++  0x8046,
++  0x8052,
++  0x8058,
++  0x805A,
++  0x805F,
++  0x8062,
++  0x8068,
++  0x8073,
++  0x8072,
++  0x8070,
++  0x8076,
++  0x8079,
++  0x807D,
++  0x807F,
++  0x8084,
++  0x8086,
++  0x8085,
++  0x809B,
++  0x8093,
++  0x809A,
++  0x80AD,
++  0x5190,
++  0x80AC,
++  0x80DB,
++  0x80E5,
++  0x80D9,
++  0x80DD,
++  0x80C4,
++  0x80DA,
++  0x80D6,
++  0x8109,
++  0x80EF,
++  0x80F1,
++  0x811B,
++  0x8129,
++  0x8123,
++  0x812F,
++  0x814B,
++  0x968B,
++  0x8146,
++  0x813E,
++  0x8153,
++  0x8151,
++  0x80FC,
++  0x8171,
++  0x816E,
++  0x8165,
++  0x8166,
++  0x8174,
++  0x8183,
++  0x8188,
++  0x818A,
++  0x8180,
++  0x8182,
++  0x81A0,
++  0x8195,
++  0x81A4,
++  0x81A3,
++  0x815F,
++  0x8193,
++  0x81A9,
++  0x81B0,
++  0x81B5,
++  0x81BE,
++  0x81B8,
++  0x81BD,
++  0x81C0,
++  0x81C2,
++  0x81BA,
++  0x81C9,
++  0x81CD,
++  0x81D1,
++  0x81D9,
++  0x81D8,
++  0x81C8,
++  0x81DA,
++  0x81DF,
++  0x81E0,
++  0x81E7,
++  0x81FA,
++  0x81FB,
++  0x81FE,
++  0x8201,
++  0x8202,
++  0x8205,
++  0x8207,
++  0x820A,
++  0x820D,
++  0x8210,
++  0x8216,
++  0x8229,
++  0x822B,
++  0x8238,
++  0x8233,
++  0x8240,
++  0x8259,
++  0x8258,
++  0x825D,
++  0x825A,
++  0x825F,
++  0x8264,
++  0x8262,
++  0x8268,
++  0x826A,
++  0x826B,
++  0x822E,
++  0x8271,
++  0x8277,
++  0x8278,
++  0x827E,
++  0x828D,
++  0x8292,
++  0x82AB,
++  0x829F,
++  0x82BB,
++  0x82AC,
++  0x82E1,
++  0x82E3,
++  0x82DF,
++  0x82D2,
++  0x82F4,
++  0x82F3,
++  0x82FA,
++  0x8393,
++  0x8303,
++  0x82FB,
++  0x82F9,
++  0x82DE,
++  0x8306,
++  0x82DC,
++  0x8309,
++  0x82D9,
++  0x8335,
++  0x8334,
++  0x8316,
++  0x8332,
++  0x8331,
++  0x8340,
++  0x8339,
++  0x8350,
++  0x8345,
++  0x832F,
++  0x832B,
++  0x8317,
++  0x8318,
++  0x8385,
++  0x839A,
++  0x83AA,
++  0x839F,
++  0x83A2,
++  0x8396,
++  0x8323,
++  0x838E,
++  0x8387,
++  0x838A,
++  0x837C,
++  0x83B5,
++  0x8373,
++  0x8375,
++  0x83A0,
++  0x8389,
++  0x83A8,
++  0x83F4,
++  0x8413,
++  0x83EB,
++  0x83CE,
++  0x83FD,
++  0x8403,
++  0x83D8,
++  0x840B,
++  0x83C1,
++  0x83F7,
++  0x8407,
++  0x83E0,
++  0x83F2,
++  0x840D,
++  0x8422,
++  0x8420,
++  0x83BD,
++  0x8438,
++  0x8506,
++  0x83FB,
++  0x846D,
++  0x842A,
++  0x843C,
++  0x855A,
++  0x8484,
++  0x8477,
++  0x846B,
++  0x84AD,
++  0x846E,
++  0x8482,
++  0x8469,
++  0x8446,
++  0x842C,
++  0x846F,
++  0x8479,
++  0x8435,
++  0x84CA,
++  0x8462,
++  0x84B9,
++  0x84BF,
++  0x849F,
++  0x84D9,
++  0x84CD,
++  0x84BB,
++  0x84DA,
++  0x84D0,
++  0x84C1,
++  0x84C6,
++  0x84D6,
++  0x84A1,
++  0x8521,
++  0x84FF,
++  0x84F4,
++  0x8517,
++  0x8518,
++  0x852C,
++  0x851F,
++  0x8515,
++  0x8514,
++  0x84FC,
++  0x8540,
++  0x8563,
++  0x8558,
++  0x8548,
++  0x8541,
++  0x8602,
++  0x854B,
++  0x8555,
++  0x8580,
++  0x85A4,
++  0x8588,
++  0x8591,
++  0x858A,
++  0x85A8,
++  0x856D,
++  0x8594,
++  0x859B,
++  0x85EA,
++  0x8587,
++  0x859C,
++  0x8577,
++  0x857E,
++  0x8590,
++  0x85C9,
++  0x85BA,
++  0x85CF,
++  0x85B9,
++  0x85D0,
++  0x85D5,
++  0x85DD,
++  0x85E5,
++  0x85DC,
++  0x85F9,
++  0x860A,
++  0x8613,
++  0x860B,
++  0x85FE,
++  0x85FA,
++  0x8606,
++  0x8622,
++  0x861A,
++  0x8630,
++  0x863F,
++  0x864D,
++  0x4E55,
++  0x8654,
++  0x865F,
++  0x8667,
++  0x8671,
++  0x8693,
++  0x86A3,
++  0x86A9,
++  0x86AA,
++  0x868B,
++  0x868C,
++  0x86B6,
++  0x86AF,
++  0x86C4,
++  0x86C6,
++  0x86B0,
++  0x86C9,
++  0x8823,
++  0x86AB,
++  0x86D4,
++  0x86DE,
++  0x86E9,
++  0x86EC,
++  0x86DF,
++  0x86DB,
++  0x86EF,
++  0x8712,
++  0x8706,
++  0x8708,
++  0x8700,
++  0x8703,
++  0x86FB,
++  0x8711,
++  0x8709,
++  0x870D,
++  0x86F9,
++  0x870A,
++  0x8734,
++  0x873F,
++  0x8737,
++  0x873B,
++  0x8725,
++  0x8729,
++  0x871A,
++  0x8760,
++  0x875F,
++  0x8778,
++  0x874C,
++  0x874E,
++  0x8774,
++  0x8757,
++  0x8768,
++  0x876E,
++  0x8759,
++  0x8753,
++  0x8763,
++  0x876A,
++  0x8805,
++  0x87A2,
++  0x879F,
++  0x8782,
++  0x87AF,
++  0x87CB,
++  0x87BD,
++  0x87C0,
++  0x87D0,
++  0x96D6,
++  0x87AB,
++  0x87C4,
++  0x87B3,
++  0x87C7,
++  0x87C6,
++  0x87BB,
++  0x87EF,
++  0x87F2,
++  0x87E0,
++  0x880F,
++  0x880D,
++  0x87FE,
++  0x87F6,
++  0x87F7,
++  0x880E,
++  0x87D2,
++  0x8811,
++  0x8816,
++  0x8815,
++  0x8822,
++  0x8821,
++  0x8831,
++  0x8836,
++  0x8839,
++  0x8827,
++  0x883B,
++  0x8844,
++  0x8842,
++  0x8852,
++  0x8859,
++  0x885E,
++  0x8862,
++  0x886B,
++  0x8881,
++  0x887E,
++  0x889E,
++  0x8875,
++  0x887D,
++  0x88B5,
++  0x8872,
++  0x8882,
++  0x8897,
++  0x8892,
++  0x88AE,
++  0x8899,
++  0x88A2,
++  0x888D,
++  0x88A4,
++  0x88B0,
++  0x88BF,
++  0x88B1,
++  0x88C3,
++  0x88C4,
++  0x88D4,
++  0x88D8,
++  0x88D9,
++  0x88DD,
++  0x88F9,
++  0x8902,
++  0x88FC,
++  0x88F4,
++  0x88E8,
++  0x88F2,
++  0x8904,
++  0x890C,
++  0x890A,
++  0x8913,
++  0x8943,
++  0x891E,
++  0x8925,
++  0x892A,
++  0x892B,
++  0x8941,
++  0x8944,
++  0x893B,
++  0x8936,
++  0x8938,
++  0x894C,
++  0x891D,
++  0x8960,
++  0x895E,
++  0x8966,
++  0x8964,
++  0x896D,
++  0x896A,
++  0x896F,
++  0x8974,
++  0x8977,
++  0x897E,
++  0x8983,
++  0x8988,
++  0x898A,
++  0x8993,
++  0x8998,
++  0x89A1,
++  0x89A9,
++  0x89A6,
++  0x89AC,
++  0x89AF,
++  0x89B2,
++  0x89BA,
++  0x89BD,
++  0x89BF,
++  0x89C0,
++  0x89DA,
++  0x89DC,
++  0x89DD,
++  0x89E7,
++  0x89F4,
++  0x89F8,
++  0x8A03,
++  0x8A16,
++  0x8A10,
++  0x8A0C,
++  0x8A1B,
++  0x8A1D,
++  0x8A25,
++  0x8A36,
++  0x8A41,
++  0x8A5B,
++  0x8A52,
++  0x8A46,
++  0x8A48,
++  0x8A7C,
++  0x8A6D,
++  0x8A6C,
++  0x8A62,
++  0x8A85,
++  0x8A82,
++  0x8A84,
++  0x8AA8,
++  0x8AA1,
++  0x8A91,
++  0x8AA5,
++  0x8AA6,
++  0x8A9A,
++  0x8AA3,
++  0x8AC4,
++  0x8ACD,
++  0x8AC2,
++  0x8ADA,
++  0x8AEB,
++  0x8AF3,
++  0x8AE7,
++  0x8AE4,
++  0x8AF1,
++  0x8B14,
++  0x8AE0,
++  0x8AE2,
++  0x8AF7,
++  0x8ADE,
++  0x8ADB,
++  0x8B0C,
++  0x8B07,
++  0x8B1A,
++  0x8AE1,
++  0x8B16,
++  0x8B10,
++  0x8B17,
++  0x8B20,
++  0x8B33,
++  0x97AB,
++  0x8B26,
++  0x8B2B,
++  0x8B3E,
++  0x8B28,
++  0x8B41,
++  0x8B4C,
++  0x8B4F,
++  0x8B4E,
++  0x8B49,
++  0x8B56,
++  0x8B5B,
++  0x8B5A,
++  0x8B6B,
++  0x8B5F,
++  0x8B6C,
++  0x8B6F,
++  0x8B74,
++  0x8B7D,
++  0x8B80,
++  0x8B8C,
++  0x8B8E,
++  0x8B92,
++  0x8B93,
++  0x8B96,
++  0x8B99,
++  0x8B9A,
++  0x8C3A,
++  0x8C41,
++  0x8C3F,
++  0x8C48,
++  0x8C4C,
++  0x8C4E,
++  0x8C50,
++  0x8C55,
++  0x8C62,
++  0x8C6C,
++  0x8C78,
++  0x8C7A,
++  0x8C82,
++  0x8C89,
++  0x8C85,
++  0x8C8A,
++  0x8C8D,
++  0x8C8E,
++  0x8C94,
++  0x8C7C,
++  0x8C98,
++  0x621D,
++  0x8CAD,
++  0x8CAA,
++  0x8CBD,
++  0x8CB2,
++  0x8CB3,
++  0x8CAE,
++  0x8CB6,
++  0x8CC8,
++  0x8CC1,
++  0x8CE4,
++  0x8CE3,
++  0x8CDA,
++  0x8CFD,
++  0x8CFA,
++  0x8CFB,
++  0x8D04,
++  0x8D05,
++  0x8D0A,
++  0x8D07,
++  0x8D0F,
++  0x8D0D,
++  0x8D10,
++  0x9F4E,
++  0x8D13,
++  0x8CCD,
++  0x8D14,
++  0x8D16,
++  0x8D67,
++  0x8D6D,
++  0x8D71,
++  0x8D73,
++  0x8D81,
++  0x8D99,
++  0x8DC2,
++  0x8DBE,
++  0x8DBA,
++  0x8DCF,
++  0x8DDA,
++  0x8DD6,
++  0x8DCC,
++  0x8DDB,
++  0x8DCB,
++  0x8DEA,
++  0x8DEB,
++  0x8DDF,
++  0x8DE3,
++  0x8DFC,
++  0x8E08,
++  0x8E09,
++  0x8DFF,
++  0x8E1D,
++  0x8E1E,
++  0x8E10,
++  0x8E1F,
++  0x8E42,
++  0x8E35,
++  0x8E30,
++  0x8E34,
++  0x8E4A,
++  0x8E47,
++  0x8E49,
++  0x8E4C,
++  0x8E50,
++  0x8E48,
++  0x8E59,
++  0x8E64,
++  0x8E60,
++  0x8E2A,
++  0x8E63,
++  0x8E55,
++  0x8E76,
++  0x8E72,
++  0x8E7C,
++  0x8E81,
++  0x8E87,
++  0x8E85,
++  0x8E84,
++  0x8E8B,
++  0x8E8A,
++  0x8E93,
++  0x8E91,
++  0x8E94,
++  0x8E99,
++  0x8EAA,
++  0x8EA1,
++  0x8EAC,
++  0x8EB0,
++  0x8EC6,
++  0x8EB1,
++  0x8EBE,
++  0x8EC5,
++  0x8EC8,
++  0x8ECB,
++  0x8EDB,
++  0x8EE3,
++  0x8EFC,
++  0x8EFB,
++  0x8EEB,
++  0x8EFE,
++  0x8F0A,
++  0x8F05,
++  0x8F15,
++  0x8F12,
++  0x8F19,
++  0x8F13,
++  0x8F1C,
++  0x8F1F,
++  0x8F1B,
++  0x8F0C,
++  0x8F26,
++  0x8F33,
++  0x8F3B,
++  0x8F39,
++  0x8F45,
++  0x8F42,
++  0x8F3E,
++  0x8F4C,
++  0x8F49,
++  0x8F46,
++  0x8F4E,
++  0x8F57,
++  0x8F5C,
++  0x8F62,
++  0x8F63,
++  0x8F64,
++  0x8F9C,
++  0x8F9F,
++  0x8FA3,
++  0x8FAD,
++  0x8FAF,
++  0x8FB7,
++  0x8FDA,
++  0x8FE5,
++  0x8FE2,
++  0x8FEA,
++  0x8FEF,
++  0x9087,
++  0x8FF4,
++  0x9005,
++  0x8FF9,
++  0x8FFA,
++  0x9011,
++  0x9015,
++  0x9021,
++  0x900D,
++  0x901E,
++  0x9016,
++  0x900B,
++  0x9027,
++  0x9036,
++  0x9035,
++  0x9039,
++  0x8FF8,
++  0x904F,
++  0x9050,
++  0x9051,
++  0x9052,
++  0x900E,
++  0x9049,
++  0x903E,
++  0x9056,
++  0x9058,
++  0x905E,
++  0x9068,
++  0x906F,
++  0x9076,
++  0x96A8,
++  0x9072,
++  0x9082,
++  0x907D,
++  0x9081,
++  0x9080,
++  0x908A,
++  0x9089,
++  0x908F,
++  0x90A8,
++  0x90AF,
++  0x90B1,
++  0x90B5,
++  0x90E2,
++  0x90E4,
++  0x6248,
++  0x90DB,
++  0x9102,
++  0x9112,
++  0x9119,
++  0x9132,
++  0x9130,
++  0x914A,
++  0x9156,
++  0x9158,
++  0x9163,
++  0x9165,
++  0x9169,
++  0x9173,
++  0x9172,
++  0x918B,
++  0x9189,
++  0x9182,
++  0x91A2,
++  0x91AB,
++  0x91AF,
++  0x91AA,
++  0x91B5,
++  0x91B4,
++  0x91BA,
++  0x91C0,
++  0x91C1,
++  0x91C9,
++  0x91CB,
++  0x91D0,
++  0x91D6,
++  0x91DF,
++  0x91E1,
++  0x91DB,
++  0x91FC,
++  0x91F5,
++  0x91F6,
++  0x921E,
++  0x91FF,
++  0x9214,
++  0x922C,
++  0x9215,
++  0x9211,
++  0x925E,
++  0x9257,
++  0x9245,
++  0x9249,
++  0x9264,
++  0x9248,
++  0x9295,
++  0x923F,
++  0x924B,
++  0x9250,
++  0x929C,
++  0x9296,
++  0x9293,
++  0x929B,
++  0x925A,
++  0x92CF,
++  0x92B9,
++  0x92B7,
++  0x92E9,
++  0x930F,
++  0x92FA,
++  0x9344,
++  0x932E,
++  0x9319,
++  0x9322,
++  0x931A,
++  0x9323,
++  0x933A,
++  0x9335,
++  0x933B,
++  0x935C,
++  0x9360,
++  0x937C,
++  0x936E,
++  0x9356,
++  0x93B0,
++  0x93AC,
++  0x93AD,
++  0x9394,
++  0x93B9,
++  0x93D6,
++  0x93D7,
++  0x93E8,
++  0x93E5,
++  0x93D8,
++  0x93C3,
++  0x93DD,
++  0x93D0,
++  0x93C8,
++  0x93E4,
++  0x941A,
++  0x9414,
++  0x9413,
++  0x9403,
++  0x9407,
++  0x9410,
++  0x9436,
++  0x942B,
++  0x9435,
++  0x9421,
++  0x943A,
++  0x9441,
++  0x9452,
++  0x9444,
++  0x945B,
++  0x9460,
++  0x9462,
++  0x945E,
++  0x946A,
++  0x9229,
++  0x9470,
++  0x9475,
++  0x9477,
++  0x947D,
++  0x945A,
++  0x947C,
++  0x947E,
++  0x9481,
++  0x947F,
++  0x9582,
++  0x9587,
++  0x958A,
++  0x9594,
++  0x9596,
++  0x9598,
++  0x9599,
++  0x95A0,
++  0x95A8,
++  0x95A7,
++  0x95AD,
++  0x95BC,
++  0x95BB,
++  0x95B9,
++  0x95BE,
++  0x95CA,
++  0x6FF6,
++  0x95C3,
++  0x95CD,
++  0x95CC,
++  0x95D5,
++  0x95D4,
++  0x95D6,
++  0x95DC,
++  0x95E1,
++  0x95E5,
++  0x95E2,
++  0x9621,
++  0x9628,
++  0x962E,
++  0x962F,
++  0x9642,
++  0x964C,
++  0x964F,
++  0x964B,
++  0x9677,
++  0x965C,
++  0x965E,
++  0x965D,
++  0x965F,
++  0x9666,
++  0x9672,
++  0x966C,
++  0x968D,
++  0x9698,
++  0x9695,
++  0x9697,
++  0x96AA,
++  0x96A7,
++  0x96B1,
++  0x96B2,
++  0x96B0,
++  0x96B4,
++  0x96B6,
++  0x96B8,
++  0x96B9,
++  0x96CE,
++  0x96CB,
++  0x96C9,
++  0x96CD,
++  0x894D,
++  0x96DC,
++  0x970D,
++  0x96D5,
++  0x96F9,
++  0x9704,
++  0x9706,
++  0x9708,
++  0x9713,
++  0x970E,
++  0x9711,
++  0x970F,
++  0x9716,
++  0x9719,
++  0x9724,
++  0x972A,
++  0x9730,
++  0x9739,
++  0x973D,
++  0x973E,
++  0x9744,
++  0x9746,
++  0x9748,
++  0x9742,
++  0x9749,
++  0x975C,
++  0x9760,
++  0x9764,
++  0x9766,
++  0x9768,
++  0x52D2,
++  0x976B,
++  0x9771,
++  0x9779,
++  0x9785,
++  0x977C,
++  0x9781,
++  0x977A,
++  0x9786,
++  0x978B,
++  0x978F,
++  0x9790,
++  0x979C,
++  0x97A8,
++  0x97A6,
++  0x97A3,
++  0x97B3,
++  0x97B4,
++  0x97C3,
++  0x97C6,
++  0x97C8,
++  0x97CB,
++  0x97DC,
++  0x97ED,
++  0x9F4F,
++  0x97F2,
++  0x7ADF,
++  0x97F6,
++  0x97F5,
++  0x980F,
++  0x980C,
++  0x9838,
++  0x9824,
++  0x9821,
++  0x9837,
++  0x983D,
++  0x9846,
++  0x984F,
++  0x984B,
++  0x986B,
++  0x986F,
++  0x9870,
++  0x9871,
++  0x9874,
++  0x9873,
++  0x98AA,
++  0x98AF,
++  0x98B1,
++  0x98B6,
++  0x98C4,
++  0x98C3,
++  0x98C6,
++  0x98E9,
++  0x98EB,
++  0x9903,
++  0x9909,
++  0x9912,
++  0x9914,
++  0x9918,
++  0x9921,
++  0x991D,
++  0x991E,
++  0x9924,
++  0x9920,
++  0x992C,
++  0x992E,
++  0x993D,
++  0x993E,
++  0x9942,
++  0x9949,
++  0x9945,
++  0x9950,
++  0x994B,
++  0x9951,
++  0x9952,
++  0x994C,
++  0x9955,
++  0x9997,
++  0x9998,
++  0x99A5,
++  0x99AD,
++  0x99AE,
++  0x99BC,
++  0x99DF,
++  0x99DB,
++  0x99DD,
++  0x99D8,
++  0x99D1,
++  0x99ED,
++  0x99EE,
++  0x99F1,
++  0x99F2,
++  0x99FB,
++  0x99F8,
++  0x9A01,
++  0x9A0F,
++  0x9A05,
++  0x99E2,
++  0x9A19,
++  0x9A2B,
++  0x9A37,
++  0x9A45,
++  0x9A42,
++  0x9A40,
++  0x9A43,
++  0x9A3E,
++  0x9A55,
++  0x9A4D,
++  0x9A5B,
++  0x9A57,
++  0x9A5F,
++  0x9A62,
++  0x9A65,
++  0x9A64,
++  0x9A69,
++  0x9A6B,
++  0x9A6A,
++  0x9AAD,
++  0x9AB0,
++  0x9ABC,
++  0x9AC0,
++  0x9ACF,
++  0x9AD1,
++  0x9AD3,
++  0x9AD4,
++  0x9ADE,
++  0x9ADF,
++  0x9AE2,
++  0x9AE3,
++  0x9AE6,
++  0x9AEF,
++  0x9AEB,
++  0x9AEE,
++  0x9AF4,
++  0x9AF1,
++  0x9AF7,
++  0x9AFB,
++  0x9B06,
++  0x9B18,
++  0x9B1A,
++  0x9B1F,
++  0x9B22,
++  0x9B23,
++  0x9B25,
++  0x9B27,
++  0x9B28,
++  0x9B29,
++  0x9B2A,
++  0x9B2E,
++  0x9B2F,
++  0x9B32,
++  0x9B44,
++  0x9B43,
++  0x9B4F,
++  0x9B4D,
++  0x9B4E,
++  0x9B51,
++  0x9B58,
++  0x9B74,
++  0x9B93,
++  0x9B83,
++  0x9B91,
++  0x9B96,
++  0x9B97,
++  0x9B9F,
++  0x9BA0,
++  0x9BA8,
++  0x9BB4,
++  0x9BC0,
++  0x9BCA,
++  0x9BB9,
++  0x9BC6,
++  0x9BCF,
++  0x9BD1,
++  0x9BD2,
++  0x9BE3,
++  0x9BE2,
++  0x9BE4,
++  0x9BD4,
++  0x9BE1,
++  0x9C3A,
++  0x9BF2,
++  0x9BF1,
++  0x9BF0,
++  0x9C15,
++  0x9C14,
++  0x9C09,
++  0x9C13,
++  0x9C0C,
++  0x9C06,
++  0x9C08,
++  0x9C12,
++  0x9C0A,
++  0x9C04,
++  0x9C2E,
++  0x9C1B,
++  0x9C25,
++  0x9C24,
++  0x9C21,
++  0x9C30,
++  0x9C47,
++  0x9C32,
++  0x9C46,
++  0x9C3E,
++  0x9C5A,
++  0x9C60,
++  0x9C67,
++  0x9C76,
++  0x9C78,
++  0x9CE7,
++  0x9CEC,
++  0x9CF0,
++  0x9D09,
++  0x9D08,
++  0x9CEB,
++  0x9D03,
++  0x9D06,
++  0x9D2A,
++  0x9D26,
++  0x9DAF,
++  0x9D23,
++  0x9D1F,
++  0x9D44,
++  0x9D15,
++  0x9D12,
++  0x9D41,
++  0x9D3F,
++  0x9D3E,
++  0x9D46,
++  0x9D48,
++  0x9D5D,
++  0x9D5E,
++  0x9D64,
++  0x9D51,
++  0x9D50,
++  0x9D59,
++  0x9D72,
++  0x9D89,
++  0x9D87,
++  0x9DAB,
++  0x9D6F,
++  0x9D7A,
++  0x9D9A,
++  0x9DA4,
++  0x9DA9,
++  0x9DB2,
++  0x9DC4,
++  0x9DC1,
++  0x9DBB,
++  0x9DB8,
++  0x9DBA,
++  0x9DC6,
++  0x9DCF,
++  0x9DC2,
++  0x9DD9,
++  0x9DD3,
++  0x9DF8,
++  0x9DE6,
++  0x9DED,
++  0x9DEF,
++  0x9DFD,
++  0x9E1A,
++  0x9E1B,
++  0x9E1E,
++  0x9E75,
++  0x9E79,
++  0x9E7D,
++  0x9E81,
++  0x9E88,
++  0x9E8B,
++  0x9E8C,
++  0x9E92,
++  0x9E95,
++  0x9E91,
++  0x9E9D,
++  0x9EA5,
++  0x9EA9,
++  0x9EB8,
++  0x9EAA,
++  0x9EAD,
++  0x9761,
++  0x9ECC,
++  0x9ECE,
++  0x9ECF,
++  0x9ED0,
++  0x9ED4,
++  0x9EDC,
++  0x9EDE,
++  0x9EDD,
++  0x9EE0,
++  0x9EE5,
++  0x9EE8,
++  0x9EEF,
++  0x9EF4,
++  0x9EF6,
++  0x9EF7,
++  0x9EF9,
++  0x9EFB,
++  0x9EFC,
++  0x9EFD,
++  0x9F07,
++  0x9F08,
++  0x76B7,
++  0x9F15,
++  0x9F21,
++  0x9F2C,
++  0x9F3E,
++  0x9F4A,
++  0x9F52,
++  0x9F54,
++  0x9F63,
++  0x9F5F,
++  0x9F60,
++  0x9F61,
++  0x9F66,
++  0x9F67,
++  0x9F6C,
++  0x9F6A,
++  0x9F77,
++  0x9F72,
++  0x9F76,
++  0x9F95,
++  0x9F9C,
++  0x9FA0,
++  0x582F,
++  0x69C7,
++  0x9059,
++  0x7464,
++  0x51DC,
++  0x7199
++};
++
++/* f5 to fe is non-existent */
+diff --git a/msys/rt/src/newlib/libc/ctype/local.h b/msys/rt/src/newlib/libc/ctype/local.h
+new file mode 100644
+index 0000000..4382404
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/local.h
+@@ -0,0 +1,32 @@
++/* wctrans constants */
++
++#include <_ansi.h>
++
++/* valid values for wctrans_t */
++#define WCT_TOLOWER 1
++#define WCT_TOUPPER 2
++
++/* valid values for wctype_t */
++#define WC_ALNUM	1
++#define WC_ALPHA	2
++#define WC_BLANK	3
++#define WC_CNTRL	4
++#define WC_DIGIT	5
++#define WC_GRAPH	6
++#define WC_LOWER	7
++#define WC_PRINT	8
++#define WC_PUNCT	9
++#define WC_SPACE	10
++#define WC_UPPER	11
++#define WC_XDIGIT	12
++
++extern char *__locale_charset(_NOARGS);
++
++/* internal function to translate JP to Unicode */
++#if defined(__CYGWIN__) || defined(__MSYS__)
++/* Under Cygwin, the incoming wide character is already given in UTF due
++   to the requirements of the underlying OS. */
++#define _jp2uc(c) (c)
++#else
++wint_t _EXFUN (_jp2uc, (wint_t));
++#endif
+diff --git a/msys/rt/src/newlib/libc/ctype/towctrans.c b/msys/rt/src/newlib/libc/ctype/towctrans.c
+new file mode 100644
+index 0000000..416a491
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/towctrans.c
+@@ -0,0 +1,97 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<towctrans>>---extensible wide-character translation
++
++INDEX
++	towctrans
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	wint_t towctrans(wint_t <[c]>, wctrans_t <[w]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	wint_t towctrans(<[c]>, <[w]>)
++	wint_t <[c]>;
++	wctrans_t <[w]>;
++
++
++DESCRIPTION
++<<towctrans>> is a function which converts wide characters based on
++a specified translation type <[w]>.  If the translation type is
++invalid or cannot be applied to the current character, no change
++to the character is made.
++
++RETURNS
++<<towctrans>> returns the translated equivalent of <[c]> when it is a
++valid for the given translation, otherwise, it returns the input character.
++When the translation type is invalid, <<errno>> is set <<EINVAL>>.
++
++PORTABILITY
++<<towctrans>> is C99.
++
++No supporting OS subroutines are required.
++*/
++
++#include <_ansi.h>
++#include <string.h>
++#include <reent.h>
++#include <wctype.h>
++#include <errno.h>
++#include "local.h"
++
++wint_t
++_DEFUN (_towctrans_r, (r, c, w), 
++	struct _reent *r _AND
++	wint_t c _AND 
++	wctrans_t w)
++{
++  if (w == WCT_TOLOWER)
++    return towlower (c);
++  else if (w == WCT_TOUPPER)
++    return towupper (c);
++  else
++    {
++      r->_errno = EINVAL;
++      return c;
++    }
++}
++
++#ifndef _REENT_ONLY
++wint_t
++_DEFUN (towctrans, (c, w),
++	wint_t c _AND
++        wctrans_t w)
++{
++  return _towctrans_r (_REENT, c, w);
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/ctype/towlower.c b/msys/rt/src/newlib/libc/ctype/towlower.c
+new file mode 100644
+index 0000000..f4d70b6
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/towlower.c
+@@ -0,0 +1,569 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<towlower>>---translate wide characters to lowercase
++
++INDEX
++	towlower
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	wint_t towlower(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	wint_t towlower(<[c]>)
++	wint_t <[c]>;
++
++
++DESCRIPTION
++<<towlower>> is a function which converts uppercase wide characters to
++lowercase, leaving all other characters unchanged.
++
++RETURNS
++<<towlower>> returns the lowercase equivalent of <[c]> when it is a
++uppercase wide character; otherwise, it returns the input character.
++
++PORTABILITY
++<<towlower>> is C99.
++
++No supporting OS subroutines are required.
++*/
++
++#include <_ansi.h>
++#include <newlib.h>
++#include <string.h>
++#include <reent.h>
++#include <ctype.h>
++#include <wctype.h>
++#include "local.h"
++
++wint_t
++_DEFUN(towlower,(c), wint_t c)
++{
++#ifdef _MB_CAPABLE
++  c = _jp2uc (c);
++  /* Based on and tested against Unicode 5.2 */
++
++  /* Expression used to filter out the characters for the below code:
++
++     awk -F\; '{ if ( $14 != "" ) print $1; }' UnicodeData.txt
++  */
++  if (c < 0x100)
++    {
++      if ((c >= 0x0041 && c <= 0x005a) ||
++	  (c >= 0x00c0 && c <= 0x00d6) ||
++	  (c >= 0x00d8 && c <= 0x00de))
++	return (c + 0x20);
++
++      return c;
++    }
++  else if (c < 0x300)
++    {
++      if ((c >= 0x0100 && c <= 0x012e) ||
++	  (c >= 0x0132 && c <= 0x0136) ||
++	  (c >= 0x014a && c <= 0x0176) ||
++	  (c >= 0x01de && c <= 0x01ee) ||
++	  (c >= 0x01f8 && c <= 0x021e) ||
++	  (c >= 0x0222 && c <= 0x0232))
++	{
++	  if (!(c & 0x01))
++	    return (c + 1);
++	  return c;
++	}
++
++      if (c == 0x0130)
++	return 0x0069;
++
++      if ((c >= 0x0139 && c <= 0x0147) ||
++	  (c >= 0x01cd && c <= 0x01db))
++	{
++	  if (c & 0x01)
++	    return (c + 1);
++	  return c;
++	}
++      
++      if (c >= 0x178 && c <= 0x01f7)
++	{
++	  wint_t k;
++	  switch (c)
++	    {
++	    case 0x0178:
++	      k = 0x00ff;
++	      break;
++	    case 0x0179:
++	    case 0x017b:
++	    case 0x017d:
++	    case 0x0182:
++	    case 0x0184:
++	    case 0x0187:
++	    case 0x018b:
++	    case 0x0191:
++	    case 0x0198:
++	    case 0x01a0:
++	    case 0x01a2:
++	    case 0x01a4:
++	    case 0x01a7:
++	    case 0x01ac:
++	    case 0x01af:
++	    case 0x01b3:
++	    case 0x01b5:
++	    case 0x01b8:
++	    case 0x01bc:
++	    case 0x01c5:
++	    case 0x01c8:
++	    case 0x01cb:
++	    case 0x01cd:
++	    case 0x01cf:
++	    case 0x01d1:
++	    case 0x01d3:
++	    case 0x01d5:
++	    case 0x01d7:
++	    case 0x01d9:
++	    case 0x01db:
++	    case 0x01f2:
++	    case 0x01f4:
++	      k = c + 1;
++	      break;
++	    case 0x0181:
++	      k = 0x0253;
++	      break;
++	    case 0x0186:
++	      k = 0x0254;
++	      break;
++	    case 0x0189:
++	      k = 0x0256;
++	      break;
++	    case 0x018a:
++	      k = 0x0257;
++	      break;
++	    case 0x018e:
++	      k = 0x01dd;
++	      break;
++	    case 0x018f:
++	      k = 0x0259;
++	      break;
++	    case 0x0190:
++	      k = 0x025b;
++	      break;
++	    case 0x0193:
++	      k = 0x0260;
++	      break;
++	    case 0x0194:
++	      k = 0x0263;
++	      break;
++	    case 0x0196:
++	      k = 0x0269;
++	      break;
++	    case 0x0197:
++	      k = 0x0268;
++	      break;
++	    case 0x019c:
++	      k = 0x026f;
++	      break;
++	    case 0x019d:
++	      k = 0x0272;
++	      break;
++	    case 0x019f:
++	      k = 0x0275;
++	      break;
++	    case 0x01a6:
++	      k = 0x0280;
++	      break;
++	    case 0x01a9:
++	      k = 0x0283;
++	      break;
++	    case 0x01ae:
++	      k = 0x0288;
++	      break;
++	    case 0x01b1:
++	      k = 0x028a;
++	      break;
++	    case 0x01b2:
++	      k = 0x028b;
++	      break;
++	    case 0x01b7:
++	      k = 0x0292;
++	      break;
++	    case 0x01c4:
++	    case 0x01c7:
++	    case 0x01ca:
++	    case 0x01f1:
++	      k = c + 2;
++	      break;
++	    case 0x01f6:
++	      k = 0x0195;
++	      break;
++	    case 0x01f7:
++	      k = 0x01bf;
++	      break;
++	    default:
++	      k = 0;
++	    }
++	  if (k != 0)
++	    return k;
++	}
++      else if (c == 0x0220)
++      	return 0x019e;
++      else if (c >= 0x023a && c <= 0x024e)
++      	{
++	  wint_t k;
++	  switch (c)
++	    {
++	    case 0x023a:
++	      k = 0x2c65;
++	      break;
++	    case 0x023b:
++	    case 0x0241:
++	    case 0x0246:
++	    case 0x0248:
++	    case 0x024a:
++	    case 0x024c:
++	    case 0x024e:
++	      k = c + 1;
++	      break;
++	    case 0x023d:
++	      k = 0x019a;
++	      break;
++	    case 0x023e:
++	      k = 0x2c66;
++	      break;
++	    case 0x0243:
++	      k = 0x0180;
++	      break;
++	    case 0x0244:
++	      k = 0x0289;
++	      break;
++	    case 0x0245:
++	      k = 0x028c;
++	      break;
++	    default:
++	      k = 0;
++	    }
++	  if (k != 0)
++	    return k;
++	}
++    }
++  else if (c < 0x0400)
++    {
++      if (c == 0x0370 || c == 0x0372 || c == 0x0376)
++      	return (c + 1);
++      if (c >= 0x0391 && c <= 0x03ab && c != 0x03a2)
++	return (c + 0x20);
++      if (c >= 0x03d8 && c <= 0x03ee && !(c & 0x01))
++	return (c + 1);
++      if (c >= 0x0386 && c <= 0x03ff)
++	{
++	  wint_t k;
++	  switch (c)
++	    {
++	    case 0x0386:
++	      k = 0x03ac;
++	      break;
++	    case 0x0388:
++	      k = 0x03ad;
++	      break;
++	    case 0x0389:
++	      k = 0x03ae;
++	      break;
++	    case 0x038a:
++	      k = 0x03af;
++	      break;
++	    case 0x038c:
++	      k = 0x03cc;
++	      break;
++	    case 0x038e:
++	      k = 0x03cd;
++	      break;
++	    case 0x038f:
++	      k = 0x03ce;
++	      break;
++	    case 0x03cf:
++	      k = 0x03d7;
++	      break;
++	    case 0x03f4:
++	      k = 0x03b8;
++	      break;
++	    case 0x03f7:
++	      k = 0x03f8;
++	      break;
++	    case 0x03f9:
++	      k = 0x03f2;
++	      break;
++	    case 0x03fa:
++	      k = 0x03fb;
++	      break;
++	    case 0x03fd:
++	      k = 0x037b;
++	      break;
++	    case 0x03fe:
++	      k = 0x037c;
++	      break;
++	    case 0x03ff:
++	      k = 0x037d;
++	      break;
++	    default:
++	      k = 0;
++	    }
++	  if (k != 0)
++	    return k;
++	}
++    }
++  else if (c < 0x500)
++    {
++      if (c >= 0x0400 && c <= 0x040f)
++	return (c + 0x50);
++      
++      if (c >= 0x0410 && c <= 0x042f)
++	return (c + 0x20);
++      
++      if ((c >= 0x0460 && c <= 0x0480) ||
++	  (c >= 0x048a && c <= 0x04be) ||
++	  (c >= 0x04d0 && c <= 0x04fe))
++	{
++	  if (!(c & 0x01))
++	    return (c + 1);
++	  return c;
++	}
++      
++      if (c == 0x04c0)
++	return 0x04cf;
++
++      if (c >= 0x04c1 && c <= 0x04cd)
++	{
++	  if (c & 0x01)
++	    return (c + 1);
++	  return c;
++	}
++    }
++  else if (c < 0x1f00)
++    {
++      if ((c >= 0x0500 && c <= 0x050e) ||
++	  (c >= 0x0510 && c <= 0x0524) ||
++	  (c >= 0x1e00 && c <= 0x1e94) ||
++	  (c >= 0x1ea0 && c <= 0x1ef8))
++	{
++	  if (!(c & 0x01))
++	    return (c + 1);
++	  return c;
++	}
++      
++      if (c >= 0x0531 && c <= 0x0556)
++	return (c + 0x30);
++
++      if (c >= 0x10a0 && c <= 0x10c5)
++	return (c + 0x1c60);
++
++      if (c == 0x1e9e)
++	return 0x00df;
++
++      if (c >= 0x1efa && c <= 0x1efe && !(c & 0x01))
++	return (c + 1);
++    }
++  else if (c < 0x2000)
++    {
++      if ((c >= 0x1f08 && c <= 0x1f0f) ||
++	  (c >= 0x1f18 && c <= 0x1f1d) ||
++	  (c >= 0x1f28 && c <= 0x1f2f) ||
++	  (c >= 0x1f38 && c <= 0x1f3f) ||
++	  (c >= 0x1f48 && c <= 0x1f4d) ||
++	  (c >= 0x1f68 && c <= 0x1f6f) ||
++	  (c >= 0x1f88 && c <= 0x1f8f) ||
++	  (c >= 0x1f98 && c <= 0x1f9f) ||
++	  (c >= 0x1fa8 && c <= 0x1faf))
++	return (c - 0x08);
++
++      if (c >= 0x1f59 && c <= 0x1f5f)
++	{
++	  if (c & 0x01)
++	    return (c - 0x08);
++	  return c;
++	}
++    
++      if (c >= 0x1fb8 && c <= 0x1ffc)
++	{
++	  wint_t k;
++	  switch (c)
++	    {
++	    case 0x1fb8:
++	    case 0x1fb9:
++	    case 0x1fd8:
++	    case 0x1fd9:
++	    case 0x1fe8:
++	    case 0x1fe9:
++	      k = c - 0x08;
++	      break;
++	    case 0x1fba:
++	    case 0x1fbb:
++	      k = c - 0x4a;
++	      break;
++	    case 0x1fbc:
++	      k = 0x1fb3;
++	      break;
++	    case 0x1fc8:
++	    case 0x1fc9:
++	    case 0x1fca:
++	    case 0x1fcb:
++	      k = c - 0x56;
++	      break;
++	    case 0x1fcc:
++	      k = 0x1fc3;
++	      break;
++	    case 0x1fda:
++	    case 0x1fdb:
++	      k = c - 0x64;
++	      break;
++	    case 0x1fea:
++	    case 0x1feb:
++	      k = c - 0x70;
++	      break;
++	    case 0x1fec:
++	      k = 0x1fe5;
++	      break;
++	    case 0x1ff8:
++	    case 0x1ff9:
++	      k = c - 0x80;
++	      break;
++	    case 0x1ffa:
++	    case 0x1ffb:
++	      k = c - 0x7e;
++	      break;
++	    case 0x1ffc:
++	      k = 0x1ff3;
++	      break;
++	    default:
++	      k = 0;
++	    }
++	  if (k != 0)
++	    return k;
++	}
++    }
++  else if (c < 0x2c00)
++    {
++      if (c >= 0x2160 && c <= 0x216f)
++	return (c + 0x10);
++
++      if (c >= 0x24b6 && c <= 0x24cf)
++	return (c + 0x1a);
++      
++      switch (c)
++      	{
++	case 0x2126:
++	  return 0x03c9;
++	case 0x212a:
++	  return 0x006b;
++	case 0x212b:
++	  return 0x00e5;
++	case 0x2132:
++	  return 0x214e;
++	case 0x2183:
++	  return 0x2184;
++	}
++    }
++  else if (c < 0x2d00)
++    {
++      if (c >= 0x2c00 && c <= 0x2c2e)
++	return (c + 0x30);
++
++      if (c >= 0x2c80 && c <= 0x2ce2 && !(c & 0x01))
++	return (c + 1);
++
++      switch (c)
++      	{
++	case 0x2c60:
++	  return 0x2c61;
++	case 0x2c62:
++	  return 0x026b;
++	case 0x2c63:
++	  return 0x1d7d;
++	case 0x2c64:
++	  return 0x027d;
++	case 0x2c67:
++	case 0x2c69:
++	case 0x2c6b:
++	case 0x2c72:
++	case 0x2c75:
++	case 0x2ceb:
++	case 0x2ced:
++	  return c + 1;
++	case 0x2c6d:
++	  return 0x0251;
++	case 0x2c6e:
++	  return 0x0271;
++	case 0x2c6f:
++	  return 0x0250;
++	case 0x2c70:
++	  return 0x0252;
++	case 0x2c7e:
++	  return 0x023f;
++	case 0x2c7f:
++	  return 0x0240;
++	}
++    }
++  else if (c >= 0xa600 && c < 0xa800)
++    {
++      if ((c >= 0xa640 && c <= 0xa65e) ||
++	  (c >= 0xa662 && c <= 0xa66c) ||
++	  (c >= 0xa680 && c <= 0xa696) ||
++	  (c >= 0xa722 && c <= 0xa72e) ||
++	  (c >= 0xa732 && c <= 0xa76e) ||
++	  (c >= 0xa77f && c <= 0xa786))
++	{
++	  if (!(c & 1))
++	    return (c + 1);
++	  return c;
++	}
++
++      switch (c)
++      	{
++	case 0xa779:
++	case 0xa77b:
++	case 0xa77e:
++	case 0xa78b:
++	  return (c + 1);
++	case 0xa77d:
++	  return 0x1d79;
++	}
++    }
++  else
++    {
++      if (c >= 0xff21 && c <= 0xff3a)
++	return (c + 0x20);
++      
++      if (c >= 0x10400 && c <= 0x10427)
++	return (c + 0x28);
++    }
++  return c;
++#else
++  return (c < 0x00ff ? (wint_t)(tolower ((int)c)) : c);
++#endif /* _MB_CAPABLE */
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/towupper.c b/msys/rt/src/newlib/libc/ctype/towupper.c
+new file mode 100644
+index 0000000..8b1755b
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/towupper.c
+@@ -0,0 +1,590 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<towupper>>---translate wide characters to uppercase
++
++INDEX
++	towupper
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	wint_t towupper(wint_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	wint_t towupper(<[c]>)
++	wint_t <[c]>;
++
++
++DESCRIPTION
++<<towupper>> is a function which converts lowercase wide characters to
++uppercase, leaving all other characters unchanged.
++
++RETURNS
++<<towupper>> returns the uppercase equivalent of <[c]> when it is a
++lowercase wide character, otherwise, it returns the input character.
++
++PORTABILITY
++<<towupper>> is C99.
++
++No supporting OS subroutines are required.
++*/
++
++#include <_ansi.h>
++#include <newlib.h>
++#include <string.h>
++#include <reent.h>
++#include <ctype.h>
++#include <wctype.h>
++#include "local.h"
++
++wint_t
++_DEFUN(towupper,(c), wint_t c)
++{
++#ifdef _MB_CAPABLE
++  c = _jp2uc (c);
++  /* Based on and tested against Unicode 5.2 */
++
++  /* Expression used to filter out the characters for the below code:
++
++     awk -F\; '{ if ( $13 != "" ) print $1; }' UnicodeData.txt
++  */
++  if (c < 0x100)
++    {
++      if (c == 0x00b5)
++	return 0x039c;
++      
++      if ((c >= 0x00e0 && c <= 0x00fe && c != 0x00f7) ||
++	  (c >= 0x0061 && c <= 0x007a))
++	return (c - 0x20);
++      
++      if (c == 0xff)
++	return 0x0178;
++      
++      return c;
++    }
++  else if (c < 0x300)
++    {
++      if ((c >= 0x0101 && c <= 0x012f) ||
++	  (c >= 0x0133 && c <= 0x0137) ||
++	  (c >= 0x014b && c <= 0x0177) ||
++	  (c >= 0x01df && c <= 0x01ef) ||
++	  (c >= 0x01f9 && c <= 0x021f) ||
++	  (c >= 0x0223 && c <= 0x0233) ||
++	  (c >= 0x0247 && c <= 0x024f))
++	{
++	  if (c & 0x01)
++	    return (c - 1);
++	  return c;
++	}
++
++      if ((c >= 0x013a && c <= 0x0148) ||
++	  (c >= 0x01ce && c <= 0x01dc) ||
++	  c == 0x023c || c == 0x0242)
++	{
++	  if (!(c & 0x01))
++	    return (c - 1);
++	  return c;
++	}
++      
++      if (c == 0x0131)
++	return 0x0049;
++      
++      if (c == 0x017a || c == 0x017c || c == 0x017e)
++	return (c - 1);
++      
++      if (c >= 0x017f && c <= 0x0292)
++	{
++	  wint_t k;
++	  switch (c)
++	    {
++	    case 0x017f:
++	      k = 0x0053;
++	      break;
++	    case 0x0180:
++	      k = 0x0243;
++	      break;
++	    case 0x0183:
++	      k = 0x0182;
++	      break;
++	    case 0x0185:
++	      k = 0x0184;
++	      break;
++	    case 0x0188:
++	      k = 0x0187;
++	      break;
++	    case 0x018c:
++	      k = 0x018b;
++	      break;
++	    case 0x0192:
++	      k = 0x0191;
++	      break;
++	    case 0x0195:
++	      k = 0x01f6;
++	      break;
++	    case 0x0199:
++	      k = 0x0198;
++	      break;
++	    case 0x019a:
++	      k = 0x023d;
++	      break;
++	    case 0x019e:
++	      k = 0x0220;
++	      break;
++	    case 0x01a1:
++	    case 0x01a3:
++	    case 0x01a5:
++	    case 0x01a8:
++	    case 0x01ad:
++	    case 0x01b0:
++	    case 0x01b4:
++	    case 0x01b6:
++	    case 0x01b9:
++	    case 0x01bd:
++	    case 0x01c5:
++	    case 0x01c8:
++	    case 0x01cb:
++	    case 0x01f2:
++	    case 0x01f5:
++	      k = c - 1;
++	      break;
++	    case 0x01bf:
++	      k = 0x01f7;
++	      break;
++	    case 0x01c6:
++	    case 0x01c9:
++	    case 0x01cc:
++	      k = c - 2;
++	      break;
++	    case 0x01dd:
++	      k = 0x018e;
++	      break;
++	    case 0x01f3:
++	      k = 0x01f1;
++	      break;
++	    case 0x023f:
++	      k = 0x2c7e;
++	      break;
++	    case 0x0240:
++	      k = 0x2c7f;
++	      break;
++	    case 0x0250:
++	      k = 0x2c6f;
++	      break;
++	    case 0x0251:
++	      k = 0x2c6d;
++	      break;
++	    case 0x0252:
++	      k = 0x2c70;
++	      break;
++	    case 0x0253:
++	      k = 0x0181;
++	      break;
++	    case 0x0254:
++	      k = 0x0186;
++	      break;
++	    case 0x0256:
++	      k = 0x0189;
++	      break;
++	    case 0x0257:
++	      k = 0x018a;
++	      break;
++	    case 0x0259:
++	      k = 0x018f;
++	      break;
++	    case 0x025b:
++	      k = 0x0190;
++	      break;
++	    case 0x0260:
++	      k = 0x0193;
++	      break;
++	    case 0x0263:
++	      k = 0x0194;
++	      break;
++	    case 0x0268:
++	      k = 0x0197;
++	      break;
++	    case 0x0269:
++	      k = 0x0196;
++	      break;
++	    case 0x026b:
++	      k = 0x2c62;
++	      break;
++	    case 0x026f:
++	      k = 0x019c;
++	      break;
++	    case 0x0271:
++	      k = 0x2c6e;
++	      break;
++	    case 0x0272:
++	      k = 0x019d;
++	      break;
++	    case 0x0275:
++	      k = 0x019f;
++	      break;
++	    case 0x027d:
++	      k = 0x2c64;
++	      break;
++	    case 0x0280:
++	      k = 0x01a6;
++	      break;
++	    case 0x0283:
++	      k = 0x01a9;
++	      break;
++	    case 0x0288:
++	      k = 0x01ae;
++	      break;
++	    case 0x0289:
++	      k = 0x0244;
++	      break;
++	    case 0x028a:
++	      k = 0x01b1;
++	      break;
++	    case 0x028b:
++	      k = 0x01b2;
++	      break;
++	    case 0x028c:
++	      k = 0x0245;
++	      break;
++	    case 0x0292:
++	      k = 0x01b7;
++	      break;
++	    default:
++	      k = 0;
++	    }
++	  if (k != 0)
++	    return k;
++	}
++    }
++  else if (c < 0x0400)
++    {
++      wint_t k;
++
++      if (c >= 0x03ad && c <= 0x03af)
++      	return (c - 0x25);
++
++      if (c >= 0x03b1 && c <= 0x03cb && c != 0x03c2)
++	return (c - 0x20);
++      
++      if (c >= 0x03d9 && c <= 0x03ef && (c & 1))
++	return (c - 1);
++
++      switch (c)
++	{
++	case 0x0345:
++	  k = 0x0399;
++	  break;
++	case 0x0371:
++	case 0x0373:
++	case 0x0377:
++	case 0x03f8:
++	case 0x03fb:
++	  k = c - 1;
++	  break;
++	case 0x037b:
++	case 0x037c:
++	case 0x037d:
++	  k = c + 0x82;
++	  break;
++	case 0x03ac:
++	  k = 0x0386;
++	  break;
++	case 0x03c2:
++	  k = 0x03a3;
++	  break;
++	case 0x03cc:
++	  k = 0x038c;
++	  break;
++	case 0x03cd:
++	case 0x03ce:
++	  k = c - 0x3f;
++	  break;
++	case 0x03d0:
++	  k = 0x0392;
++	  break;
++	case 0x03d1:
++	  k = 0x0398;
++	  break;
++	case 0x03d5:
++	  k = 0x03a6;
++	  break;
++	case 0x03d6:
++	  k = 0x03a0;
++	  break;
++	case 0x03d7:
++	  k = 0x03cf;
++	  break;
++	case 0x03f0:
++	  k = 0x039a;
++	  break;
++	case 0x03f1:
++	  k = 0x03a1;
++	  break;
++	case 0x03f2:
++	  k = 0x03f9;
++	  break;
++	case 0x03f5:
++	  k = 0x0395;
++	  break;
++	default:
++	  k = 0;
++	}
++      if (k != 0)
++	return k;
++    }
++  else if (c < 0x500)
++    {
++      if (c >= 0x0430 && c <= 0x044f)
++	return (c - 0x20);
++      
++      if (c >= 0x0450 && c <= 0x045f)
++	return (c - 0x50);
++      
++      if ((c >= 0x0461 && c <= 0x0481) ||
++	  (c >= 0x048b && c <= 0x04bf) ||
++	  (c >= 0x04d1 && c <= 0x04ff))
++	{
++	  if (c & 0x01)
++	    return (c - 1);
++	  return c;
++	}
++      
++      if (c >= 0x04c2 && c <= 0x04ce)
++	{
++	  if (!(c & 0x01))
++	    return (c - 1);
++	  return c;
++	}
++      
++      if (c == 0x04cf)
++      	return 0x04c0;
++
++      if (c >= 0x04f7 && c <= 0x04f9)
++	return (c - 1);
++    }
++  else if (c < 0x0600)
++    {
++      if (c >= 0x0501 && c <= 0x0525 && (c & 1))
++      	return c - 1;
++
++      if (c >= 0x0561 && c <= 0x0586)
++	return (c - 0x30);
++    }
++  else if (c < 0x1f00)
++    {
++      if (c == 0x1d79)
++      	return 0xa77d;
++
++      if (c == 0x1d7d)
++      	return 0x2c63;
++
++      if ((c >= 0x1e01 && c <= 0x1e95) ||
++	  (c >= 0x1ea1 && c <= 0x1eff))
++	{
++	  if (c & 0x01)
++	    return (c - 1);
++	  return c;
++	}
++      
++      if (c == 0x1e9b)
++	return 0x1e60;
++    }
++  else if (c < 0x2000)
++    {
++      
++      if ((c >= 0x1f00 && c <= 0x1f07) ||
++	  (c >= 0x1f10 && c <= 0x1f15) ||
++	  (c >= 0x1f20 && c <= 0x1f27) ||
++	  (c >= 0x1f30 && c <= 0x1f37) ||
++	  (c >= 0x1f40 && c <= 0x1f45) ||
++	  (c >= 0x1f60 && c <= 0x1f67) ||
++	  (c >= 0x1f80 && c <= 0x1f87) ||
++	  (c >= 0x1f90 && c <= 0x1f97) ||
++	  (c >= 0x1fa0 && c <= 0x1fa7))
++	return (c + 0x08);
++
++      if (c >= 0x1f51 && c <= 0x1f57 && (c & 0x01))
++	return (c + 0x08);
++      
++      if (c >= 0x1f70 && c <= 0x1ff3)
++	{
++	  wint_t k;
++	  switch (c)
++	    {
++	    case 0x1fb0:
++	      k = 0x1fb8;
++	      break;
++	    case 0x1fb1:
++	      k = 0x1fb9;
++	      break;
++	    case 0x1f70:
++	      k = 0x1fba;
++	      break;
++	    case 0x1f71:
++	      k = 0x1fbb;
++	      break;
++	    case 0x1fb3:
++	      k = 0x1fbc;
++	      break;
++	    case 0x1fbe:
++	      k = 0x0399;
++	      break;
++	    case 0x1f72:
++	      k = 0x1fc8;
++	      break;
++	    case 0x1f73:
++	      k = 0x1fc9;
++	      break;
++	    case 0x1f74:
++	      k = 0x1fca;
++	      break;
++	    case 0x1f75:
++	      k = 0x1fcb;
++	      break;
++	    case 0x1fc3:
++	      k = 0x1fcc;
++	      break;
++	    case 0x1fd0:
++	      k = 0x1fd8;
++	      break;
++	    case 0x1fd1:
++	      k = 0x1fd9;
++	      break;
++	    case 0x1f76:
++	      k = 0x1fda;
++	      break;
++	    case 0x1f77:
++	      k = 0x1fdb;
++	      break;
++	    case 0x1fe0:
++	      k = 0x1fe8;
++	      break;
++	    case 0x1fe1:
++	      k = 0x1fe9;
++	      break;
++	    case 0x1f7a:
++	      k = 0x1fea;
++	      break;
++	    case 0x1f7b:
++	      k = 0x1feb;
++	      break;
++	    case 0x1fe5:
++	      k = 0x1fec;
++	      break;
++	    case 0x1f78:
++	      k = 0x1ff8;
++	      break;
++	    case 0x1f79:
++	      k = 0x1ff9;
++	      break;
++	    case 0x1f7c:
++	      k = 0x1ffa;
++	      break;
++	    case 0x1f7d:
++	      k = 0x1ffb;
++	      break;
++	    case 0x1ff3:
++	      k = 0x1ffc;
++	      break;
++	    default:
++	      k = 0;
++	    }
++	  if (k != 0)
++	    return k;
++	}
++    }
++  else if (c < 0x3000)
++    {
++      if (c == 0x214e)
++      	return 0x2132;
++
++      if (c == 0x2184)
++      	return 0x2183;
++
++      if (c >= 0x2170 && c <= 0x217f)
++	return (c - 0x10);
++      
++      if (c >= 0x24d0 && c <= 0x24e9)
++	return (c - 0x1a);
++      
++      if (c >= 0x2c30 && c <= 0x2c5e)
++	return (c - 0x30);
++
++      if ((c >= 0x2c68 && c <= 0x2c6c && !(c & 1)) ||
++	  (c >= 0x2c81 && c <= 0x2ce3 &&  (c & 1)) ||
++	  c == 0x2c73 || c == 0x2c76 ||
++	  c == 0x2cec || c == 0x2cee)
++      	return (c - 1);
++
++      if (c >= 0x2c81 && c <= 0x2ce3 && (c & 1))
++	return (c - 1);
++
++      if (c >= 0x2d00 && c <= 0x2d25)
++      	return (c - 0x1c60);
++
++      switch (c)
++      	{
++	case 0x2c61:
++	  return 0x2c60;
++	case 0x2c65:
++	  return 0x023a;
++	case 0x2c66:
++	  return 0x023e;
++	}
++    }
++  else if (c >= 0xa000 && c < 0xb000)
++    {
++      if (((c >= 0xa641 && c <= 0xa65f) ||
++           (c >= 0xa663 && c <= 0xa66d) ||
++           (c >= 0xa681 && c <= 0xa697) ||
++           (c >= 0xa723 && c <= 0xa72f) ||
++           (c >= 0xa733 && c <= 0xa76f) ||
++           (c >= 0xa77f && c <= 0xa787)) &&
++	  (c & 1))
++	return (c - 1);
++      	
++      if (c == 0xa77a || c == 0xa77c || c == 0xa78c)
++	return (c - 1);
++    }
++  else
++    {
++      if (c >= 0xff41 && c <= 0xff5a)
++	return (c - 0x20);
++      
++      if (c >= 0x10428 && c <= 0x1044f)
++	return (c - 0x28);
++    }
++  return c;
++#else
++  return (c < 0x00ff ? (wint_t)(toupper ((int)c)) : c);
++#endif /* _MB_CAPABLE */
++}
++
+diff --git a/msys/rt/src/newlib/libc/ctype/utf8alpha.h b/msys/rt/src/newlib/libc/ctype/utf8alpha.h
+new file mode 100644
+index 0000000..d9306b7
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/utf8alpha.h
+@@ -0,0 +1,355 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/* Generated using UnicodeData.txt 5.2 */
++
++/* Expression used to filter out the characters for the below tables:
++
++  awk -F\; \
++  '{ \
++    VAL = strtonum (sprintf("0x%s", $1)); \
++    # All of general category "L", except for two Thai characters which \
++    # are actually punctuation characters.  Old Unicode weirdness. \
++    # The character "COMBINING GREEK YPOGEGRAMMENI", as well as all Thai \
++    # characters which are in "Mn" category.  Old Unicode weirdness. \
++    # All numerical digit or letter characters, except the ASCII variants. \
++    # This is necessary due to the unfortunate ISO C definition for the \
++    # iswdigit class, otherwise these characters are missing in iswalnum. \
++    # All "Other Symbols" which are named as "LETTER" characters. \
++    # \
++    # Before running this test, make sure to expand all Unicode blocks \
++    # which are just marked by their first and last character! \
++    # \
++    if (   (match($3, "^L") && VAL != 0x0e2f && VAL != 0x0e46) \
++	|| (match($3, "^Mn") && (VAL == 0x0345 || match($2, "\\<CHARACTER\\>"))) \
++	|| (match($3, "^N[dl]") && VAL >= 0x100) \
++	|| (match($3, "^So") && match($2, "\\<LETTER\\>"))) \
++      print $1; \
++  }' UnicodeData.txt
++*/
++
++static const unsigned char u0[] = {
++  0x41, 0x0, 0x5a, 0x61, 0x0, 0x7a, 0xaa, 0xb5, 
++  0xba, 0xc0, 0x0, 0xd6, 0xd8, 0x0, 0xf6, 0xf8, 
++  0x0, 0xff };
++/* u1 all alphabetic */
++static const unsigned char u2[] = {
++  0x00, 0x0, 0xc1, 0xc6, 0x0, 0xd1,
++  0xe0, 0x0, 0xe4, 0xec, 0xee };
++static const unsigned char u3[] = {
++  0x45, 0x70, 0x0, 0x74, 0x76, 0x77,
++  0x7a, 0x0, 0x7d, 0x86, 0x88, 0x0, 0x8a, 0x8c,
++  0x8e, 0x0, 0xa1, 0xa3, 0x0, 0xf5,
++  0xf7, 0x0, 0xff };
++static const unsigned char u4[] = { 
++  0x00, 0x0, 0x81, 0x8a, 0x0, 0xff };
++static const unsigned char u5[] = { 
++  0x00, 0x0, 0x25, 0x31, 0x0, 0x56, 0x59, 
++  0x61, 0x0, 0x87, 0xd0, 0x0, 0xea,
++  0xf0, 0x0, 0xf2 };
++static const unsigned char u6[] = { 
++  0x21, 0x0, 0x4a, 0x60, 0x0, 0x69,
++  0x6e, 0x0, 0x6f, 0x71, 0x0, 0xd3, 
++  0xd5, 0xe5, 0x0, 0xe6, 0xee, 0x0, 0xfc, 0xff };
++static const unsigned char u7[] = { 
++  0x10, 0x12, 0x0, 0x2f, 0x4d, 0x0, 0xa5, 0xb1,
++  0xc0, 0x0, 0xea, 0xf4, 0xf5, 0xfa };
++static const unsigned char u8[] = { 
++  0x00, 0x0, 0x15, 0x1a, 0x24, 0x28 };
++static const unsigned char u9[] = { 
++  0x04, 0x0, 0x39, 0x3d, 0x50, 0x58, 0x0, 0x61,
++  0x66, 0x0, 0x6f, 0x71, 0x72, 0x79, 0x0, 0x7f,
++  0x85, 0x0, 0x8c, 0x8f, 0x0, 0x90, 
++  0x93, 0x0, 0xa8, 0xaa, 0x0, 0xb0, 0xb2,
++  0xb6, 0x0, 0xb9, 0xbd, 0xce, 0xdc, 0x0, 0xdd,
++  0xdf, 0x0, 0xe1, 0xe6, 0x0, 0xf1 };
++static const unsigned char ua[] = { 
++  0x05, 0x0, 0x0a, 0x0f, 0x0, 0x10,
++  0x13, 0x0, 0x28, 0x2a, 0x0, 0x30,
++  0x32, 0x0, 0x33, 0x35, 0x0, 0x36,
++  0x38, 0x0, 0x39, 0x59, 0x0, 0x5c,
++  0x5e, 0x66, 0x0, 0x6f, 0x72, 0x0, 0x74,
++  0x85, 0x0, 0x8d, 0x8f, 0x0, 0x91,
++  0x93, 0x0, 0xa8, 0xaa, 0x0, 0xb0,
++  0xb2, 0x0, 0xb3, 0xb5, 0x0, 0xb9,
++  0xbd, 0xd0, 0xe0, 0xe1, 0xe6, 0x0, 0xef };
++static const unsigned char ub[] = { 
++  0x05, 0x0, 0x0c, 0x0f, 0x0, 0x10,
++  0x13, 0x0, 0x28, 0x2a, 0x0, 0x30,
++  0x32, 0x0, 0x33, 0x35, 0x0, 0x39, 0x3d,
++  0x5c, 0x0, 0x5d, 0x5f, 0x0, 0x61,
++  0x66, 0x0, 0x6f, 0x71, 0x83, 0x85, 0x0, 0x8a,
++  0x8e, 0x0, 0x90, 0x92, 0x0, 0x95,
++  0x99, 0x0, 0x9a, 0x9c, 0x9e, 0x0, 0x9f,
++  0xa3, 0x0, 0xa4, 0xa8, 0x0, 0xaa,
++  0xae, 0x0, 0xb9, 0xd0, 0xe6, 0x0, 0xef };
++static const unsigned char uc[] = { 
++  0x05, 0x0, 0x0c, 0x0e, 0x0, 0x10,
++  0x12, 0x0, 0x28, 0x2a, 0x0, 0x33,
++  0x35, 0x0, 0x39, 0x3d, 0x58, 0x59,
++  0x60, 0x0, 0x61, 0x66, 0x0, 0x6f,
++  0x85, 0x0, 0x8c, 0x8e, 0x0, 0x90,
++  0x92, 0x0, 0xa8, 0xaa, 0x0, 0xb3,
++  0xb5, 0x0, 0xb9, 0xbd, 0xde, 0xe0, 0x0, 0xe1,
++  0xe6, 0x0, 0xef };
++static const unsigned char ud[] = { 
++  0x05, 0x0, 0x0c, 0x0e, 0x0, 0x10, 
++  0x12, 0x0, 0x28, 0x2a, 0x0, 0x39, 0x3d,
++  0x60, 0x0, 0x61, 0x66, 0x0, 0x6f,
++  0x7a, 0x0, 0x7f, 0x85, 0x0, 0x96, 0x9a, 
++  0x0, 0xb1, 0xb3, 0x0, 0xbb, 0xbd,
++  0xc0, 0x0, 0xc6 };
++static const unsigned char ue[] = { 
++  0x01, 0x0, 0x2e, 0x30, 0x0, 0x3a, 0x40, 
++  0x0, 0x45, 0x47, 0x0, 0x4e, 0x50, 0x0, 0x59, 
++  0x81, 0x0, 0x82, 0x84, 0x87, 0x0, 0x88, 0x8a, 
++  0x8d, 0x94, 0x0, 0x97, 0x99, 0x0, 0x9f, 0xa1, 
++  0x0, 0xa3, 0xa5, 0xa7, 0xaa, 0x0, 0xab, 0xad, 
++  0x0, 0xb0, 0xb2, 0x0, 0xb3, 0xbd, 0xc0, 0x0, 
++  0xc4, 0xc6, 0xd0, 0x0, 0xd9, 0xdc, 0x0, 0xdd }; 
++static const unsigned char uf[] = {
++  0x00, 0x20, 0x0, 0x29, 0x40, 0x0, 0x47, 0x49, 
++  0x0, 0x6c, 0x88, 0x0, 0x8b };
++static const unsigned char u10[] = { 
++  0x00, 0x0, 0x2a, 0x3f, 0x0, 0x49,
++  0x50, 0x0, 0x55, 0x5a, 0x0, 0x5d,
++  0x61, 0x65, 0x66, 0x6e, 0x0, 0x70,
++  0x75, 0x0, 0x81, 0x8e, 0x90, 0x0, 0x99,
++  0xa0, 0x0, 0xc5, 0xd0, 0x0, 0xfa, 0xfc };
++/* u11 all alphabetic */
++static const unsigned char u12[] = { 
++  0x00, 0x0, 0x48, 0x4a, 0x0, 0x4d,
++  0x50, 0x0, 0x56, 0x58, 0x5a, 0x0, 0x5d,
++  0x60, 0x0, 0x88, 0x8a, 0x0, 0x8d,
++  0x90, 0x0, 0xb0, 0xb2, 0x0, 0xb5,
++  0xb8, 0x0, 0xbe, 0xc0, 0xc2, 0x0, 0xc5,
++  0xc8, 0x0, 0xd6, 0xd8, 0x0, 0xff };
++static const unsigned char u13[] = { 
++  0x00, 0x0, 0x10, 0x12, 0x0, 0x15,
++  0x18, 0x0, 0x5a, 0x80, 0x0, 0x8f,
++  0xa0, 0x0, 0xf4 };
++static const unsigned char u14[] = { 
++  0x01, 0x0, 0xff };
++/* u15 all alphabetic */
++static const unsigned char u16[] = { 
++  0x00, 0x0, 0x6c, 0x6f, 0x0, 0x7f, 
++  0x81, 0x0, 0x9a, 0xa0, 0x0, 0xea,
++  0xee, 0x0, 0xf0 };
++static const unsigned char u17[] = { 
++  0x00, 0x0, 0x0c, 0x0e, 0x0, 0x11,
++  0x20, 0x0, 0x31, 0x40, 0x0, 0x51,
++  0x60, 0x0, 0x6c, 0x6e, 0x0, 0x70,
++  0x80, 0x0, 0xb3, 0xd7, 0xdc, 0xe0, 0x0, 0xe9 };
++static const unsigned char u18[] = { 
++  0x10, 0x0, 0x19, 0x20, 0x0, 0x77,
++  0x80, 0x0, 0xa8, 0xaa, 0xb0, 0x0, 0xf5 };
++static const unsigned char u19[] = { 
++  0x00, 0x0, 0x1c, 0x46, 0x0, 0x6d,
++  0x70, 0x0, 0x74, 0x80, 0x0, 0xab,
++  0xc1, 0x0, 0xc7, 0xd0, 0x0, 0xda };
++static const unsigned char u1a[] = { 
++  0x00, 0x0, 0x16, 0x20, 0x0, 0x54,
++  0x80, 0x0, 0x89, 0x90, 0x0, 0x99, 0xa7 };
++static const unsigned char u1b[] = { 
++  0x05, 0x0, 0x33, 0x45, 0x0, 0x4b,
++  0x50, 0x0, 0x59, 0x83, 0x0, 0xa0,
++  0xae, 0x0, 0xb9 };
++static const unsigned char u1c[] = { 
++  0x00, 0x0, 0x23, 0x40, 0x0, 0x49,
++  0x4d, 0x0, 0x7d, 0xe9, 0x0, 0xec,
++  0xee, 0x0, 0xf1 };
++static const unsigned char u1d[] = { 
++  0x00, 0x0, 0xbf };
++/* u1e all alphabetic */
++static const unsigned char u1f[] = { 
++  0x00, 0x0, 0x15, 0x18, 0x0, 0x1d, 
++  0x20, 0x0, 0x45, 0x48, 0x0, 0x4d, 0x50, 0x0, 0x57, 0x59, 
++  0x5b, 0x5d, 0x5f, 0x0, 0x7d, 0x80, 0x0, 0xb4, 
++  0xb6, 0x0, 0xbc, 0xbe, 0xc2, 0x0, 0xc4, 0xc6, 
++  0x0, 0xcc, 0xd0, 0x0, 0xd3, 0xd6, 0x0, 0xdb, 
++  0xe0, 0x0, 0xec, 0xf2, 0x0, 0xf4, 0xf6, 0x0, 
++  0xfc };
++static const unsigned char u20[] = { 
++  0x71, 0x7f, 0x90, 0x0, 0x94 };
++static const unsigned char u21[] = { 
++  0x02, 0x07, 0x0a, 0x0, 0x13, 0x15,
++  0x19, 0x0, 0x1d, 0x24, 0x26, 0x28, 0x0, 0x2d,
++  0x2f, 0x0, 0x39, 0x3c, 0x0, 0x3f,
++  0x45, 0x0, 0x49, 0x4e, 0x60, 0x0, 0x88 }; 
++static const unsigned char u24[] = { 
++  0x9c, 0x0, 0xe9 };
++static const unsigned char u2c[] = { 
++  0x00, 0x0, 0x2e, 0x30, 0x0, 0x5e,
++  0x60, 0x0, 0xe4, 0xeb, 0x0, 0xee };
++static const unsigned char u2d[] = { 
++  0x00, 0x0, 0x25, 0x30, 0x0, 0x65, 0x6f,
++  0x80, 0x0, 0x96, 0xa0, 0x0, 0xa6,
++  0xa8, 0x0, 0xae, 0xb0, 0x0, 0xb6,
++  0xb8, 0x0, 0xbe, 0xc0, 0x0, 0xc6,
++  0xc8, 0x0, 0xce, 0xd0, 0x0, 0xd6,
++  0xd8, 0x0, 0xde };
++static const unsigned char u2e[] = {
++  0x2f };
++static const unsigned char u30[] = { 
++  0x05, 0x0, 0x07, 0x21, 0x0, 
++  0x29, 0x31, 0x0, 0x35, 0x38, 0x0, 0x3c, 0x41, 
++  0x0, 0x96, 0x9d, 0x0, 0x9f, 0xa1, 0x0, 0xfa, 
++  0xfc, 0x0, 0xff };
++static const unsigned char u31[] = { 
++  0x05, 0x0, 0x2d, 0x31, 0x0, 
++  0x8e, 0xa0, 0x0, 0xb7, 0xf0, 0x0, 0xff };
++/* u34 to u4c all alphabetic */
++static const unsigned char u4d[] = { 
++  0x00, 0x0, 0xb5 };
++/* u4e to u9e all alphabetic */
++static const unsigned char u9f[] = { 
++  0x00, 0x0, 0xcb };
++/* ua0 to ua3 all alphabetic */
++static const unsigned char ua4[] = { 
++  0x00, 0x0, 0x8c, 0xd0, 0x0, 0xfd }; 
++/* ua5 all alphabetic */
++static const unsigned char ua6[] = {
++  0x00, 0x0, 0x0c, 0x10, 0x0, 0x2b,
++  0x40, 0x0, 0x5f, 0x62, 0x0, 0x6e,
++  0x7f, 0x0, 0x97, 0xa0, 0x0, 0xef };
++static const unsigned char ua7[] = {
++  0x17, 0x0, 0x1f, 0x22, 0x0, 0x88,
++  0x8b, 0x8c,
++  0xfb, 0x0, 0xff };
++static const unsigned char ua8[] = {
++  0x00, 0x01, 0x03, 0x0, 0x05, 0x07, 0x0, 0x0a,
++  0x0c, 0x0, 0x22, 0x40, 0x0, 0x73,
++  0x82, 0x0, 0xb3, 0xd0, 0x0, 0xd9,
++  0xf2, 0x0, 0xf7, 0xfb };
++static const unsigned char ua9[] = {
++  0x00, 0x0, 0x25, 0x30, 0x0, 0x46,
++  0x60, 0x0, 0x7c, 0x84, 0x0, 0xb2,
++  0xcf, 0x0, 0xd9 };
++static const unsigned char uaa[] = {
++  0x00, 0x0, 0x28, 0x40, 0x0, 0x42,
++  0x44, 0x0, 0x4b, 0x50, 0x0, 0x59,
++  0x60, 0x0, 0x76, 0x7a, 0x80, 0x0, 0xaf,
++  0xb1, 0xb5, 0xb6, 0xb9, 0x0, 0xbd,
++  0xc0, 0xc2, 0xdb, 0x0, 0xdd };
++static const unsigned char uab[] = {
++  0xc0, 0x0, 0xe2, 0xf0, 0x0, 0xf9 };
++/* uac to ud6 all alphabetic */
++static const unsigned char ud7[] = { 
++  0x00, 0x0, 0xa3, 0xb0, 0x0, 0xc6,
++  0xcb, 0x0, 0xfb };
++/* uf9 all alphabetic */
++static const unsigned char ufa[] = { 
++  0x00, 0x0, 0x2d, 0x30, 0x0, 0x6d,
++  0x70, 0x0, 0xd9 };
++static const unsigned char ufb[] = { 
++  0x00, 0x0, 0x06, 0x13, 0x0, 0x17, 0x1d, 
++  0x1f, 0x0, 0x28, 0x2a, 0x0, 0x36, 0x38, 0x0, 
++  0x3c, 0x3e, 0x40, 0x0, 0x41, 0x43, 0x0, 0x44, 
++  0x46, 0x0, 0xb1, 0xd3, 0x0, 0xff };
++/* ufc all alphabetic */
++static const unsigned char ufd[] = { 
++  0x00, 0x0, 0x3d, 0x50, 0x0, 
++  0x8f, 0x92, 0x0, 0xc7, 0xf0, 0x0, 0xfb };
++static const unsigned char ufe[] = { 
++  0x70, 
++  0x0, 0x74, 0x76, 0x0, 0xfc };
++static const unsigned char uff[] = { 
++  0x10, 0x0, 0x19, 
++  0x21, 0x0, 0x3a, 0x41, 0x0, 0x5a, 0x66, 0x0, 
++  0xbe, 0xc2, 0x0, 0xc7, 0xca, 0x0, 0xcf, 0xd2, 
++  0x0, 0xd7, 0xda, 0x0, 0xdc };
++static const unsigned char u100[] = { 
++  0x00, 0x0, 0x0b, 0x0d, 0x0, 0x26,
++  0x28, 0x0, 0x3a, 0x3c, 0x3d, 0x3f, 0x0, 0x4d,
++  0x50, 0x0, 0x5d, 0x80, 0x0, 0xfa };
++static const unsigned char u101[] = { 
++  0x40, 0x0, 0x74 };
++static const unsigned char u102[] = { 
++  0x80, 0x0, 0x9c, 0xa0, 0x0, 0xd0 };
++static const unsigned char u103[] = { 
++  0x00, 0x0, 0x1e, 0x30, 0x0, 0x4a,
++  0x80, 0x0, 0x9d, 0xa0, 0x0, 0xc3,
++  0xc8, 0x0, 0xcf, 0xd1, 0x0, 0xd5 };
++static const unsigned char u104[] = { 
++  0x00, 0x0, 0x9d, 0xa0, 0x0, 0xa9 };
++static const unsigned char u108[] = { 
++  0x00, 0x0, 0x05, 0x08, 0x0a, 0x0, 0x35,
++  0x37, 0x38, 0x3c, 0x3f, 0x0, 0x55 };
++static const unsigned char u109[] = {
++  0x00, 0x0, 0x15, 0x20, 0x0, 0x39 };
++static const unsigned char u10a[] = {
++  0x00, 0x10, 0x0, 0x13, 0x15, 0x0, 0x17,
++  0x19, 0x0, 0x33, 0x60, 0x0, 0x7c };
++static const unsigned char u10b[] = {
++  0x00, 0x0, 0x35, 0x40, 0x0, 0x55,
++  0x60, 0x0, 0x72 };
++static const unsigned char u10c[] = {
++  0x00, 0x0, 0x48 };
++static const unsigned char u110[] = {
++  0x83, 0x0, 0xaf };
++/* u120 to u122 all alphabetic */
++static const unsigned char u123[] = { 
++  0x00, 0x0, 0x6e };
++static const unsigned char u124[] = { 
++  0x00, 0x0, 0x62 };
++/* u130 to u133 all alphabetic */
++static const unsigned char u134[] = {
++  0x00, 0x0, 0x2e };
++static const unsigned char u1d4[] = { 
++  0x00, 0x0, 0x54, 0x56, 0x0, 0x9c,
++  0x9e, 0x0, 0x9f, 0xa2, 0xa5, 0x0, 0xa6,
++  0xa9, 0x0, 0xac, 0xae, 0x0, 0xb9, 0xbb,
++  0xbd, 0x0, 0xc3, 0xc5, 0x0, 0xff };
++static const unsigned char u1d5[] = { 
++  0x00, 0x0, 0x05, 0x07, 0x0, 
++  0x0a, 0x0d, 0x0, 0x14, 0x16, 0x0, 0x1c, 0x1e, 
++  0x0, 0x39, 0x3b, 0x0, 0x3e, 0x40, 0x0, 0x44, 
++  0x46, 0x4a, 0x0, 0x50, 0x52, 0x0, 0xff }; 
++static const unsigned char u1d6[] = { 
++  0x00, 0x0, 0xa5, 0xa8, 0x0, 0xc0,
++  0xc2, 0x0, 0xda, 0xdc, 0x0, 0xfa, 
++  0xfc, 0x0, 0xff };
++static const unsigned char u1d7[] = { 
++  0x00, 0x0, 0x14, 0x16, 0x0, 0x34,
++  0x36, 0x0, 0x4e, 0x50, 0x0, 0x6e, 
++  0x70, 0x0, 0x88, 0x8a, 0x0, 0xa8,
++  0xaa, 0x0, 0xc2, 0xc4, 0x0, 0xcb,
++  0xce, 0x0, 0xff };
++static const unsigned char u1f1[] = {
++  0x10, 0x0, 0x2c, 0x31, 0x3d, 0x3f, 0x42, 0x46,
++  0x57, 0x5f, 0x79, 0x7b, 0x7c, 0x7f, 0x8a };
++/* u200 to u2a5 all alphabetic */
++static const unsigned char u2a6[] = { 
++  0x00, 0x0, 0xd6 };
++/* u2a7 to u2b6 all alphabetic */
++static const unsigned char u2b7[] = {
++  0x00, 0x0, 0x34 };
++/* u2f8 to u2f9 all alphabetic */
++static const unsigned char u2fa[] = { 
++  0x00, 0x0, 0x1d };
+diff --git a/msys/rt/src/newlib/libc/ctype/utf8print.h b/msys/rt/src/newlib/libc/ctype/utf8print.h
+new file mode 100644
+index 0000000..abeb81c
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/utf8print.h
+@@ -0,0 +1,389 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/* Generated using UnicodeData.txt 5.2 */
++
++/* Expression used to filter out the characters for the below tables:
++
++   awk -F\; \
++   '{ \
++     VAL = strtonum (sprintf("0x%s", $1)); \
++     # All valid characters except from categories Cc (C0 or C1 control code), \
++     # Cs (Surrogates), Zl (Line separator), and Zp (Paragraph separator).\
++     # \
++     # Before running this test, make sure to expand all Unicode blocks \
++     # which are just marked by their first and last character! \
++     # \
++     if (!match($3, "^C[cs]") && !match($3, "^Z[lp]")) \
++       print $1; \
++   }' UnicodeData.txt
++*/
++static const unsigned char u0[] = {
++  0x20, 0x0, 0x7e, 0xa0, 0x0, 0xff };
++/* u1 is all-print */
++/* u2 is all-print */
++static const unsigned char u3[] = { 
++  0x00, 0x0, 0x77, 0x7a, 0x0, 0x7e,
++  0x84, 0x0, 0x8a, 0x8c, 0x8e, 0x0, 
++  0xa1, 0xa3, 0x0, 0xff };
++/* u4 is all-print */
++static const unsigned char u5[] = {
++  0x00, 0x0, 0x25, 0x31, 0x0, 
++  0x56, 0x59, 0x0, 0x5f, 0x61, 0x0, 0x87, 0x89, 
++  0x0, 0x8a, 0x91, 0x0, 0xc7, 0xd0, 0x0, 0xea,
++  0xf0, 0x0, 0xf4 };
++static const unsigned char u6[] = {
++  0x00, 0x0, 0x03, 0x06, 0x0, 0x1b, 0x1e, 0x1f,
++  0x21, 0x0, 0x5e, 0x60, 0x0, 0xff };
++static const unsigned char u7[] = { 
++  0x00, 0x0, 0x0d, 0x0f, 0x0, 0x4a, 0x4d, 0x0, 0xb1,
++  0xc0, 0x0, 0xfa };
++static const unsigned char u8[] = { 
++  0x00, 0x0, 0x2d, 0x30, 0x0, 0x3e, };
++static const unsigned char u9[] = {
++  0x00, 0x0, 0x39, 0x3c, 0x0, 0x4e, 0x50, 0x0, 0x55, 
++  0x58, 0x0, 0x72, 0x79, 0x0, 0x7f, 0x81, 0x0, 0x83,
++  0x85, 0x0, 0x8c, 0x8f, 0x0, 0x90, 0x93, 0x0, 0xa8,
++  0xaa, 0x0, 0xb0, 0xb2, 0xb6, 0x0, 0xb9, 0xbc, 
++  0x0, 0xc4, 0xc7, 0xc8, 0xcb, 0x0, 0xce, 
++  0xd7, 0xdc, 0x0, 0xdd, 0xdf, 0x0, 0xe3, 0xe6, 
++  0x0, 0xfb };
++static const unsigned char ua[] = { 
++  0x01, 0x0, 0x03, 0x05, 0x0, 0x0a, 0x0f, 0x0, 
++  0x10, 0x13, 0x0, 0x28, 0x2a, 0x0, 0x30, 0x32, 
++  0x0, 0x33, 0x35, 0x0, 0x36, 0x38, 0x0, 0x39, 
++  0x3c, 0x3e, 0x0, 0x42, 0x47, 0x0, 0x48, 0x4b, 
++  0x0, 0x4d, 0x51, 0x59, 0x0, 0x5c, 0x5e, 0x66, 0x0, 
++  0x75, 0x81, 0x0, 0x83, 0x85, 0x0, 0x8d,
++  0x8f, 0x0, 0x91, 0x93, 0x0, 0xa8, 0xaa, 0x0, 
++  0xb0, 0xb2, 0x0, 0xb3, 0xb5, 0x0, 0xb9, 0xbc, 
++  0x0, 0xc5, 0xc7, 0x0, 0xc9, 0xcb, 0x0, 0xcd, 
++  0xd0, 0xe0, 0x0, 0xe3, 0xe6, 0x0, 0xef, 0xf1 };
++static const unsigned char ub[] = {
++  0x01, 0x0, 0x03, 
++  0x05, 0x0, 0x0c, 0x0f, 0x0, 0x10, 0x13, 0x0, 
++  0x28, 0x2a, 0x0, 0x30, 0x32, 0x0, 0x33, 0x35, 
++  0x0, 0x39, 0x3c, 0x0, 0x44, 0x47, 0x0, 0x48, 
++  0x4b, 0x0, 0x4d, 0x56, 0x0, 0x57, 0x5c, 0x0, 
++  0x5d, 0x5f, 0x0, 0x63, 0x66, 0x0, 0x71, 0x82, 
++  0x0, 0x83, 0x85, 0x0, 0x8a, 0x8e, 0x0, 0x90, 
++  0x92, 0x0, 0x95, 0x99, 0x0, 0x9a, 0x9c, 0x9e, 
++  0x0, 0x9f, 0xa3, 0x0, 0xa4, 0xa8, 0x0, 0xaa, 
++  0xae, 0x0, 0xb9, 0xbe, 0x0, 
++  0xc2, 0xc6, 0x0, 0xc8, 0xca, 0x0, 0xcd, 0xd0,
++  0xd7, 0xe6, 0xe7, 0x0, 0xfa };
++static const unsigned char uc[] = {
++  0x01, 0x0, 0x03, 0x05, 0x0, 
++  0x0c, 0x0e, 0x0, 0x10, 0x12, 0x0, 0x28, 0x2a, 
++  0x0, 0x33, 0x35, 0x0, 0x39, 0x3d, 0x0, 0x44, 
++  0x46, 0x0, 0x48, 0x4a, 0x0, 0x4d, 0x55, 0x0, 
++  0x56, 0x58, 0x59, 0x60, 0x0, 0x63, 0x66, 0x0, 0x6f,
++  0x78, 0x0, 0x7f, 0x82, 0x83, 0x85, 0x0, 0x8c,
++  0x8e, 0x0, 0x90, 0x92, 0x0, 0xa8, 0xaa, 0x0, 0xb3,
++  0xb5, 0x0, 0xb9, 0xbc, 0x0, 0xc4, 0xc6, 0x0, 0xc8,
++  0xca, 0x0, 0xcd, 0xd5, 0x0, 0xd6, 0xde, 0xe0, 0x0, 
++  0xe3, 0xe6, 0x0, 0xef, 0xf1, 0xf2 };
++static const unsigned char ud[] = {
++  0x02, 0x0, 0x03, 0x05, 
++  0x0, 0x0c, 0x0e, 0x0, 0x10, 0x12, 0x0, 0x28, 
++  0x2a, 0x0, 0x39, 0x3d, 0x0, 0x44, 0x46, 0x0, 
++  0x48, 0x4a, 0x0, 0x4d, 0x57, 0x60, 0x0, 0x63, 
++  0x66, 0x0, 0x75, 0x79, 0x0, 0x7f, 0x82, 0x0, 0x83,
++  0x85, 0x0, 0x96, 0x9a, 0x0, 0xb1, 0xb3, 0x0, 0xbb,
++  0xbd, 0xc0, 0x0, 0xc6, 0xca, 0xcf, 0x0, 0xd4, 0xd6, 
++  0xd8, 0x0, 0xdf, 0xf2, 0x0, 0xf4 };
++static const unsigned char ue[] = {
++  0x01, 0x0, 
++  0x3a, 0x3f, 0x0, 0x5b, 0x81, 0x0, 0x82, 0x84, 
++  0x87, 0x0, 0x88, 0x8a, 0x8d, 0x94, 0x0, 0x97, 
++  0x99, 0x0, 0x9f, 0xa1, 0x0, 0xa3, 0xa5, 0xa7, 
++  0xaa, 0x0, 0xab, 0xad, 0x0, 0xb9, 0xbb, 0x0, 
++  0xbd, 0xc0, 0x0, 0xc4, 0xc6, 0xc8, 0x0, 0xcd, 
++  0xd0, 0x0, 0xd9, 0xdc, 0x0, 0xdd };
++static const unsigned char uf[] = {
++  0x00, 0x0, 0x47, 0x49, 0x0, 0x6c,
++  0x71, 0x0, 0x8b, 0x90, 0x0, 0x97,
++  0x99, 0x0, 0xbc, 0xbe, 0x0, 0xcc, 
++  0xce, 0x0, 0xd8 };
++static const unsigned char u10[] = {
++  0x00, 0x0, 0xc5, 0xd0, 0x0, 0xfc };
++/* u11 is all-print */
++static const unsigned char u12[] = {
++  0x00, 0x0, 0x48, 0x4a, 0x0, 0x4d, 0x50, 0x0, 0x56, 
++  0x58, 0x5a, 0x0, 0x5d, 0x60, 0x0, 0x88, 
++  0x8a, 0x0, 0x8d, 0x90, 0x0, 0xb0, 0xb2, 
++  0x0, 0xb5, 0xb8, 0x0, 0xbe, 0xc0, 0xc2, 0x0, 
++  0xc5, 0xc8, 0x0, 0xd6, 0xd8, 0x0, 0xff };
++static const unsigned char u13[] = {
++  0x00, 0x0, 0x10, 0x12, 0x0, 0x15,
++  0x18, 0x0, 0x5a, 0x5f, 0x0, 0x7c,
++  0x80, 0x0, 0x99, 0xa0, 0x0, 0xf4 };
++/* u14 is all-print */
++/* u15 is all-print */
++static const unsigned char u16[] = {
++  0x00, 0x0, 0x9c, 0xa0, 0x0, 0xf0 };
++static const unsigned char u17[] = {
++  0x00, 0x0, 0x0c, 0x0e, 0x0, 0x14, 0x20, 
++  0x0, 0x36, 0x40, 0x0, 0x53, 0x60, 0x0, 0x6c, 
++  0x6e, 0x0, 0x70, 0x72, 0x0, 0x73, 0x80, 0x0, 
++  0xdd, 0xe0, 0x0, 0xe9, 0xf0, 0x0, 0xf9 };
++static const unsigned char u18[] = {
++  0x00, 0x0, 0x0e, 0x10, 
++  0x0, 0x19, 0x20, 0x0, 0x77, 0x80, 0x0, 0xaa,
++  0xb0, 0x0, 0xf5 };
++static const unsigned char u19[] = {
++  0x00, 0x0, 0x1c, 0x20, 0x0, 0x2b,
++  0x30, 0x0, 0x3b, 0x40, 0x44, 0x0, 0x6d,
++  0x70, 0x0, 0x74, 0x80, 0x0, 0xab,
++  0xb0, 0x0, 0xc9, 0xd0, 0x0, 0xda,
++  0xde, 0x0, 0xff };
++static const unsigned char u1a[] = {
++  0x00, 0x0, 0x1b, 0x1e, 0x0, 0x5e,
++  0x60, 0x0, 0x7c, 0x7f, 0x0, 0x89,
++  0x90, 0x0, 0x99, 0xa0, 0x0, 0xad };
++static const unsigned char u1b[] = {
++  0x00, 0x0, 0x4b, 0x50, 0x0, 0x7c,
++  0x80, 0x0, 0xaa, 0xae, 0x0, 0xb9 };
++static const unsigned char u1c[] = {
++  0x00, 0x0, 0x37, 0x3b, 0x0, 0x49,
++  0x4d, 0x0, 0x7f, 0xd0, 0x0, 0xf2 };
++static const unsigned char u1d[] = { 
++  0x00, 0x0, 0xe6, 0xfd, 0x0, 0xff };
++/* u1e is all-print */
++static const unsigned char u1f[] = {
++  0x00, 0x0, 
++  0x15, 0x18, 0x0, 0x1d, 0x20, 0x0, 0x45, 0x48, 
++  0x0, 0x4d, 0x50, 0x0, 0x57, 0x59, 0x5b, 0x5d, 
++  0x5f, 0x0, 0x7d, 0x80, 0x0, 0xb4, 0xb6, 0x0, 
++  0xc4, 0xc6, 0x0, 0xd3, 0xd6, 0x0, 0xdb, 0xdd, 
++  0x0, 0xef, 0xf2, 0x0, 0xf4, 0xf6, 0x0, 0xfe };
++static const unsigned char u20[] = { 
++  0x00, 0x0, 0x27, 0x2a, 0x0, 0x64,
++  0x6a, 0x0, 0x71, 0x74, 0x0, 0x8e, 
++  0x90, 0x0, 0x94, 0xa0, 0x0, 0xb8,
++  0xd0, 0x0, 0xf0 };
++static const unsigned char u21[] = {
++  0x00, 0x0, 0x89, 0x90, 0x0, 0xff };
++/* u22 is all-print */
++static const unsigned char u23[] = {
++  0x00, 0x0, 0xe8 };
++static const unsigned char u24[] = {
++  0x00, 0x0, 0x26, 0x40, 0x0, 0x4a, 
++  0x60, 0x0, 0xff };
++/* u25 is all-print */
++static const unsigned char u26[] = {
++  0x00, 0x0, 0xcd, 0xcf, 0x0, 0xe1,
++  0xe3, 0xe8, 0x0, 0xff };
++static const unsigned char u27[] = {
++  0x01, 0x0, 0x04, 0x06, 0x0, 0x09,
++  0x0c, 0x0, 0x27, 0x29, 0x0, 0x4b, 0x4d,
++  0x4f, 0x0, 0x52, 0x56, 0x0, 0x5e,
++  0x61, 0x0, 0x94, 0x98, 0x0, 0xaf,
++  0xb1, 0x0, 0xbe, 0xc0, 0x0, 0xca, 0xcc,
++  0xd0, 0x0, 0xff };
++/* u28 to u2a are all-print */
++static const unsigned char u2b[] = {
++  0x00, 0x0, 0x4c, 0x50, 0x0, 0x59 };
++static const unsigned char u2c[] = {
++  0x00, 0x0, 0x2e, 0x30, 0x0, 0x5e,
++  0x60, 0x0, 0xf1, 0xf9, 0x0, 0xff };
++static const unsigned char u2d[] = {
++  0x00, 0x0, 0x25, 0x30, 0x0, 0x65, 0x6f,
++  0x80, 0x0, 0x96, 0xa0, 0x0, 0xa6,
++  0xa8, 0x0, 0xae, 0xb0, 0x0, 0xb6,
++  0xb8, 0x0, 0xbe, 0xc0, 0x0, 0xc6,
++  0xc8, 0x0, 0xce, 0xd0, 0x0, 0xd6,
++  0xd8, 0x0, 0xde, 0xe0, 0x0, 0xff };
++static const unsigned char u2e[] = {
++  0x00, 0x0, 0x31, 0x80, 0x0, 0x99,
++  0x9b, 0x0, 0xf3 };
++static const unsigned char u2f[] = { 
++  0x00, 0x0, 0xd5, 0xf0, 0x0, 0xfb };
++static const unsigned char u30[] = {
++  0x00, 0x0, 
++  0x3f, 0x41, 0x0, 0x96, 0x99, 0x0, 0xff };
++static const unsigned char u31[] = {
++  0x05, 0x0, 0x2d, 0x31, 0x0, 0x8e,
++  0x90, 0x0, 0xb7, 0xc0, 0x0, 0xe3,
++  0xf0, 0x0, 0xff };
++static const unsigned char u32[] = {
++  0x00, 0x0, 0x1e, 0x20, 0x0, 0xfe };
++/* u33 to u4c is all-print */
++static const unsigned char u4d[] = { 
++  0x00, 0x0, 0xb5, 0xc0, 0x0, 0xff };
++/* u4e to u9e is all-print */
++static const unsigned char u9f[] = {
++  0x00, 0x0, 0xcb };
++/* ua0 to ua3 is all-print */
++static const unsigned char ua4[] = {
++  0x00, 0x0, 0x8c, 0x90, 0x0, 0xc6,
++  0xd0, 0x0, 0xff };
++/* ua5 is all-print */
++static const unsigned char ua6[] = {
++  0x00, 0x0, 0x2b, 0x40, 0x0, 0x5f,
++  0x62, 0x0, 0x73, 0x7c, 0x0, 0x97,
++  0xa0, 0x0, 0xf7 };
++static const unsigned char ua7[] = {
++  0x00, 0x0, 0x8c, 0xfb, 0x0, 0xff };
++static const unsigned char ua8[] = {
++  0x00, 0x0, 0x2b, 0x30, 0x0, 0x39,
++  0x40, 0x0, 0x77, 0x80, 0x0, 0xc4,
++  0xce, 0x0, 0xd9, 0xe0, 0x0, 0xfb };
++static const unsigned char ua9[] = {
++  0x00, 0x0, 0x53, 0x5f, 0x0, 0x7c,
++  0x80, 0x0, 0xcd, 0xcf, 0x0, 0xd9,
++  0xde, 0xdf };
++static const unsigned char uaa[] = {
++  0x00, 0x0, 0x36, 0x40, 0x0, 0x4d,
++  0x50, 0x0, 0x59, 0x5c, 0x0, 0x7b,
++  0x80, 0x0, 0xc2, 0xdb, 0x0, 0xdf };
++static const unsigned char uab[] = {
++  0xc0, 0x0, 0xed, 0xf0, 0x0, 0xf9 };
++/* uac to ud6 is all-print */
++static const unsigned char ud7[] = {
++  0x00, 0x0, 0xa3, 0xb0, 0x0, 0xc6,
++  0xcb, 0x0, 0xfb };
++/* ud8 to udf are UTF-16 surrogates, non-printable */
++/* ue0 to uf9 is all-print */
++static const unsigned char ufa[] = {
++  0x00, 0x0, 0x2d, 0x30, 0x0, 0x6d,
++  0x70, 0x0, 0xd9 };
++static const unsigned char ufb[] = {
++  0x00, 0x0, 0x06, 0x13, 0x0, 0x17,
++  0x1d, 0x0, 0x36, 0x38, 0x0, 0x3c,
++  0x3e, 0x40, 0x41, 0x43, 0x44, 
++  0x46, 0x0, 0xb1, 0xd3, 0x0, 0xff };
++/* ufc is all-print */
++static const unsigned char ufd[] = {
++  0x00, 0x0, 0x3f, 0x50, 0x0, 0x8f,
++  0x92, 0x0, 0xc7, 0xf0, 0x0, 0xfd };
++static const unsigned char ufe[] = {
++  0x00, 0x0, 0x19, 0x20, 0x0, 0x26,
++  0x30, 0x0, 0x52, 0x54, 0x0, 0x66,
++  0x68, 0x0, 0x6b, 0x70, 0x0, 0x74,
++  0x76, 0x0, 0xfc, 0xff };
++static const unsigned char uff[] = {
++  0x01, 0x0, 0xbe, 0xc2, 0x0, 0xc7, 0xca, 0x0, 
++  0xcf, 0xd2, 0x0, 0xd7, 0xda, 0x0, 0xdc, 0xe0, 
++  0x0, 0xe6, 0xe8, 0x0, 0xee, 0xf9, 0x0, 0xfd }; 
++static const unsigned char u100[] = {
++  0x00, 0x0, 0x0b, 0x0d, 0x0, 0x26,
++  0x28, 0x0, 0x3a, 0x3c, 0x3d, 0x3f, 0x0, 0x4d,
++  0x50, 0x0, 0x5d, 0x80, 0x0, 0xfa };
++static const unsigned char u101[] = {
++  0x00, 0x0, 0x02, 0x07, 0x0, 0x33,
++  0x37, 0x0, 0x8a, 0x90, 0x0, 0x9b,
++  0xd0, 0x0, 0xfd };
++static const unsigned char u102[] = {
++  0x80, 0x0, 0x9c, 0xa0, 0x0, 0xd0 };
++static const unsigned char u103[] = {
++  0x00, 0x0, 0x1e, 0x20, 0x0, 0x23,
++  0x30, 0x0, 0x4a, 0x80, 0x0, 0x9d,
++  0x9f, 0x0, 0xc3, 0xc8, 0x0, 0xd5 };
++static const unsigned char u104[] = {
++  0x00, 0x0, 0x9d, 0xa0, 0x0, 0xa9 };
++static const unsigned char u108[] = {
++  0x00, 0x0, 0x05, 0x08, 0x0a, 0x0, 0x35,
++  0x37, 0x38, 0x3c, 0x3f, 0x0, 0x55,
++  0x57, 0x0, 0x5f };
++static const unsigned char u109[] = {
++  0x00, 0x0, 0x1b, 0x1f, 0x0, 0x39, 0x3f };
++static const unsigned char u10a[] = {
++  0x00, 0x0, 0x03, 0x05, 0x06, 0x0c, 0x0, 0x13,
++  0x15, 0x0, 0x17, 0x19, 0x0, 0x33,
++  0x38, 0x0, 0x3a, 0x3f, 0x0, 0x47,
++  0x50, 0x0, 0x58, 0x60, 0x0, 0x7f };
++static const unsigned char u10b[] = {
++  0x00, 0x0, 0x35, 0x39, 0x0, 0x55,
++  0x58, 0x0, 0x72, 0x78, 0x0, 0x7f };
++static const unsigned char u10c[] = {
++  0x00, 0x0, 0x48 };
++static const unsigned char u10e[] = {
++  0x60, 0x0, 0x7e };
++static const unsigned char u110[] = {
++  0x80, 0x0, 0xc1 };
++/* u120 to u122 is all-print */
++static const unsigned char u123[] = {
++  0x00, 0x0, 0x6e };
++static const unsigned char u124[] = {
++  0x00, 0x0, 0x62, 0x70, 0x0, 0x73 };
++/* u130 to u133 is all-print */
++static const unsigned char u134[] = {
++  0x00, 0x0, 0x2e };
++static const unsigned char u1d0[] = {
++  0x00, 0x0, 0xf5 };
++static const unsigned char u1d1[] = {
++  0x00, 0x0, 0x26, 0x29, 0x0, 0xdd };
++static const unsigned char u1d2[] = {
++  0x00, 0x0, 0x45 };
++static const unsigned char u1d3[] = {
++  0x00, 0x0, 0x56, 0x60, 0x0, 0x71 };
++static const unsigned char u1d4[] = { 
++  0x00, 0x0, 0x54, 0x56, 0x0, 0x9c, 0x9e, 0x0, 
++  0x9f, 0xa2, 0xa5, 0x0, 0xa6, 0xa9, 0x0, 0xac, 
++  0xae, 0x0, 0xb9, 0xbb, 0xbd, 0x0, 0xc3,
++  0xc5, 0x0, 0xff };
++static const unsigned char u1d5[] = {
++  0x00, 0x0, 0x05, 0x07, 0x0, 0x0a, 
++  0x0d, 0x0, 0x14, 0x16, 0x0, 0x1c, 0x1e, 0x0, 
++  0x39, 0x3b, 0x0, 0x3e, 0x40, 0x0, 0x44, 0x46, 
++  0x4a, 0x0, 0x50, 0x52, 0x0, 0xff };
++static const unsigned char u1d6[] = {
++  0x00, 0x0, 0xa5, 0xa8, 0x0, 0xff };
++static const unsigned char u1d7[] = {
++  0x00, 0x0, 0xcb, 0xce, 0x0, 0xff };
++static const unsigned char u1f0[] = {
++  0x00, 0x0, 0x2b, 0x30, 0x0, 0x93 };
++static const unsigned char u1f1[] = {
++  0x00, 0x0, 0x0a, 0x10, 0x0, 0x2e,
++  0x31, 0x3d, 0x3f, 0x42, 0x46, 0x4a, 0x0, 0x4e,
++  0x57, 0x5f, 0x79, 0x7b, 0x7c, 0x7f, 0x8a, 0x0,
++  0x8c, 0x8d, 0x90 };
++static const unsigned char u1f2[] = {
++  0x00, 0x10, 0x0, 0x31, 0x40, 0x0, 0x48 };
++/* u200 to u2a5 is all-print */
++static const unsigned char u2a6[] = {
++  0x00, 0x0, 0xd6 };
++/* u2a7 to u2b6 is all-print */
++static const unsigned char u2b7[] = {
++  0x00, 0x0, 0x34 };
++/* u2f8 to u2f9 is all-print */
++static const unsigned char u2fa[] = {
++  0x00, 
++  0x0, 0x1d };
++static const unsigned char ue00[] = {
++  0x01, 0x20, 0x0, 0x7f };
++static const unsigned char ue01[] = {
++  0x00, 0x0, 0xef };
++/* uf00 to uffe is all-print */
++static const unsigned char ufff[] = {
++  0x00, 0x0, 0xfd };
++/* u1000 to u10fe is all-print */
++static const unsigned char u10ff[] = {
++  0x00, 0x0, 0xfd };
+diff --git a/msys/rt/src/newlib/libc/ctype/wctrans.c b/msys/rt/src/newlib/libc/ctype/wctrans.c
+new file mode 100644
+index 0000000..7506983
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/wctrans.c
+@@ -0,0 +1,94 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<wctrans>>---get wide-character translation type
++
++INDEX
++	wctrans
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	wctrans_t wctrans(const char *<[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	wctrans_t wctrans(<[c]>)
++	const char * <[c]>;
++
++
++DESCRIPTION
++<<wctrans>> is a function which takes a string <[c]> and gives back
++the appropriate wctrans_t type value associated with the string,
++if one exists.  The following values are guaranteed to be recognized:
++"tolower" and "toupper".
++
++RETURNS
++<<wctrans>> returns 0 and sets <<errno>> to <<EINVAL>> if the
++given name is invalid.  Otherwise, it returns a valid non-zero wctrans_t
++value.
++
++PORTABILITY
++<<wctrans>> is C99.
++
++No supporting OS subroutines are required.
++*/
++
++#include <_ansi.h>
++#include <string.h>
++#include <reent.h>
++#include <wctype.h>
++#include <errno.h>
++#include "local.h"
++
++wctrans_t
++_DEFUN (_wctrans_r, (r, c), 
++	struct _reent *r _AND
++	const char *c)
++{
++  if (!strcmp (c, "tolower"))
++    return WCT_TOLOWER;
++  else if (!strcmp (c, "toupper"))
++    return WCT_TOUPPER;
++  else
++    {
++      r->_errno = EINVAL;
++      return 0;
++    }
++}
++
++#ifndef _REENT_ONLY
++wctrans_t
++_DEFUN (wctrans, (c),
++	const char *c)
++{
++  return _wctrans_r (_REENT, c);
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/ctype/wctype.c b/msys/rt/src/newlib/libc/ctype/wctype.c
+new file mode 100644
+index 0000000..dc400c4
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/ctype/wctype.c
+@@ -0,0 +1,137 @@
++/* Copyright (c) 2002 Red Hat Incorporated.
++   All rights reserved.
++
++   Redistribution and use in source and binary forms, with or without
++   modification, are permitted provided that the following conditions are met:
++
++     Redistributions of source code must retain the above copyright
++     notice, this list of conditions and the following disclaimer.
++
++     Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++     The name of Red Hat Incorporated may not be used to endorse
++     or promote products derived from this software without specific
++     prior written permission.
++
++   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++   ARE DISCLAIMED.  IN NO EVENT SHALL RED HAT INCORPORATED BE LIABLE FOR ANY
++   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
++   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS   
++   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/*
++FUNCTION
++	<<wctype>>---get wide-character classification type
++
++INDEX
++	wctype
++
++ANSI_SYNOPSIS
++	#include <wctype.h>
++	wctype_t wctype(const char *<[c]>);
++
++TRAD_SYNOPSIS
++	#include <wctype.h>
++	wctype_t wctype(<[c]>)
++	const char * <[c]>;
++
++
++DESCRIPTION
++<<wctype>> is a function which takes a string <[c]> and gives back
++the appropriate wctype_t type value associated with the string,
++if one exists.  The following values are guaranteed to be recognized:
++"alnum", "alpha", "blank", "cntrl", "digit", "graph", "lower", "print",
++"punct", "space", "upper", and "xdigit".
++
++RETURNS
++<<wctype>> returns 0 and sets <<errno>> to <<EINVAL>> if the
++given name is invalid.  Otherwise, it returns a valid non-zero wctype_t
++value.
++
++PORTABILITY
++<<wctype>> is C99.
++
++No supporting OS subroutines are required.
++*/
++
++#include <_ansi.h>
++#include <string.h>
++#include <reent.h>
++#include <wctype.h>
++#include <errno.h>
++#include "local.h"
++
++wctype_t
++_DEFUN (_wctype_r, (r, c), 
++	struct _reent *r _AND
++	const char *c)
++{
++  switch (*c)
++    {
++    case 'a':
++      if (!strcmp (c, "alnum"))
++        return WC_ALNUM; 
++      else if (!strcmp (c, "alpha"))
++        return WC_ALPHA;
++      break;
++    case 'b':
++      if (!strcmp (c, "blank"))
++        return WC_BLANK;
++      break;
++    case 'c':
++      if (!strcmp (c, "cntrl"))
++        return WC_CNTRL;
++      break;
++    case 'd':
++      if (!strcmp (c, "digit"))
++        return WC_DIGIT;
++      break;
++    case 'g':
++      if (!strcmp (c, "graph"))
++        return WC_GRAPH;
++      break;
++    case 'l':
++      if (!strcmp (c, "lower"))
++        return WC_LOWER;
++      break;
++    case 'p':
++      if (!strcmp (c, "print"))
++        return WC_PRINT;
++      else if (!strcmp (c, "punct"))
++        return WC_PUNCT;
++      break;
++    case 's':
++      if (!strcmp (c, "space"))
++        return WC_SPACE;
++      break;
++    case 'u':
++      if (!strcmp (c, "upper"))
++        return WC_UPPER;
++      break;
++    case 'x':
++      if (!strcmp (c, "xdigit"))
++        return WC_XDIGIT;
++      break;
++    }
++
++  /* otherwise invalid */
++  r->_errno = EINVAL;
++  return 0;
++}
++
++#ifndef _REENT_ONLY
++wctype_t
++_DEFUN (wctype, (c),
++	const char *c)
++{
++  return _wctype_r (_REENT, c);
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/include/newlib.h b/msys/rt/src/newlib/libc/include/newlib.h
+new file mode 100644
+index 0000000..eee5964
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/include/newlib.h
+@@ -0,0 +1,5 @@
++#ifndef __NEWLIB_H__
++#define __NEWLIB_H__ 1
++
++#endif /* !__NEWLIB_H__ */
++
+diff --git a/msys/rt/src/newlib/libc/include/stdlib.h b/msys/rt/src/newlib/libc/include/stdlib.h
+index daa75ea..472b490 100644
+--- a/msys/rt/src/newlib/libc/include/stdlib.h
++++ b/msys/rt/src/newlib/libc/include/stdlib.h
+@@ -69,15 +69,15 @@ long	_EXFUN(labs,(long));
+ ldiv_t	_EXFUN(ldiv,(long __numer, long __denom));
+ _PTR	_EXFUN(malloc,(size_t __size));
+ int	_EXFUN(mblen,(const char *, size_t));
+-int	_EXFUN(_mblen_r,(struct _reent *, const char *, size_t, int *));
++int	_EXFUN(_mblen_r,(struct _reent *, const char *, size_t, _mbstate_t *));
+ int	_EXFUN(mbtowc,(wchar_t *, const char *, size_t));
+-int	_EXFUN(_mbtowc_r,(struct _reent *, wchar_t *, const char *, size_t, int *));
++int	_EXFUN(_mbtowc_r,(struct _reent *, wchar_t *, const char *, size_t, _mbstate_t *));
+ int	_EXFUN(wctomb,(char *, wchar_t));
+-int	_EXFUN(_wctomb_r,(struct _reent *, char *, wchar_t, int *));
++int	_EXFUN(_wctomb_r,(struct _reent *, char *, wchar_t, _mbstate_t *));
+ size_t	_EXFUN(mbstowcs,(wchar_t *, const char *, size_t));
+-size_t	_EXFUN(_mbstowcs_r,(struct _reent *, wchar_t *, const char *, size_t, int *));
++size_t	_EXFUN(_mbstowcs_r,(struct _reent *, wchar_t *, const char *, size_t, _mbstate_t *));
+ size_t	_EXFUN(wcstombs,(char *, const wchar_t *, size_t));
+-size_t	_EXFUN(_wcstombs_r,(struct _reent *, char *, const wchar_t *, size_t, int *));
++size_t	_EXFUN(_wcstombs_r,(struct _reent *, char *, const wchar_t *, size_t, _mbstate_t *));
+ #ifndef __STRICT_ANSI__
+ #ifndef _REENT_ONLY
+ int     _EXFUN(mkstemp,(char *));
+diff --git a/msys/rt/src/newlib/libc/include/sys/_types.h b/msys/rt/src/newlib/libc/include/sys/_types.h
+index 8186f2d..11d02a1 100644
+--- a/msys/rt/src/newlib/libc/include/sys/_types.h
++++ b/msys/rt/src/newlib/libc/include/sys/_types.h
+@@ -9,7 +9,57 @@
+ #ifndef	_SYS__TYPES_H
+ #define _SYS__TYPES_H
+ 
++#ifndef __off_t_defined
+ typedef long _off_t;
++#endif
++
++#if defined(__rtems__)
++/* device numbers are 32-bit major and and 32-bit minor */
++typedef unsigned long long __dev_t;
++#else
++#ifndef __dev_t_defined
++typedef short __dev_t;
++#endif
++#endif
++
++#ifndef __uid_t_defined
++typedef unsigned short __uid_t;
++#endif
++#ifndef __gid_t_defined
++typedef unsigned short __gid_t;
++#endif
++
++#ifndef __off64_t_defined
++__extension__ typedef long long _off64_t;
++#endif
++
++#ifndef __ssize_t_defined
++#if defined(__INT_MAX__) && __INT_MAX__ == 2147483647
++typedef int _ssize_t;
++#else
+ typedef long _ssize_t;
++#endif
++#endif
++
++#define __need_wint_t
++#include <stddef.h>
++
++#ifndef __mbstate_t_defined
++/* Conversion state information.  */
++typedef struct
++{
++  int __count;
++  union
++  {
++    wint_t __wch;
++    unsigned char __wchb[4];
++  } __value;		/* Value so far.  */
++} _mbstate_t;
++#endif
++
++#ifndef __iconv_t_defined
++/* Iconv descriptor type */
++typedef void *_iconv_t;
++#endif
+ 
+ #endif	/* _SYS__TYPES_H */
+diff --git a/msys/rt/src/newlib/libc/include/sys/errno.h b/msys/rt/src/newlib/libc/include/sys/errno.h
+index d94b0eb..5f7e532 100644
+--- a/msys/rt/src/newlib/libc/include/sys/errno.h
++++ b/msys/rt/src/newlib/libc/include/sys/errno.h
+@@ -145,6 +145,7 @@ extern __IMPORT const int sys_nerr;
+ #define ENOMEDIUM 135   /* No medium (in tape drive) */
+ #define ENOSHARE 136    /* No such host or network path */
+ #define ECASECLASH 137  /* Filename exists with different case */
++#define EILSEQ 138
+ 
+ /* From cygwin32 and MSYS.  */
+ #define EWOULDBLOCK EAGAIN	/* Operation would block */
+diff --git a/msys/rt/src/newlib/libc/include/sys/reent.h b/msys/rt/src/newlib/libc/include/sys/reent.h
+index 65417f8..a221385 100644
+--- a/msys/rt/src/newlib/libc/include/sys/reent.h
++++ b/msys/rt/src/newlib/libc/include/sys/reent.h
+@@ -150,6 +150,8 @@ struct __sFILE {
+   struct _reent *_data;
+ };
+ 
++typedef struct __sFILE   __FILE;
++
+ /*
+  * rand48 family support
+  *
+@@ -226,6 +228,14 @@ struct _reent
+           int _gamma_signgam;
+           __extension__ unsigned long long _rand_next;
+           struct _rand48 _r48;
++          _mbstate_t _mblen_state;
++          _mbstate_t _mbtowc_state;
++          _mbstate_t _wctomb_state;
++          _mbstate_t _mbrlen_state;
++          _mbstate_t _mbrtowc_state;
++          _mbstate_t _mbsrtowcs_state;
++          _mbstate_t _wcrtomb_state;
++          _mbstate_t _wcsrtombs_state;
+         } _reent;
+   /* Two next two fields were once used by malloc.  They are no longer
+      used. They are used to preserve the space used before so as to
+@@ -259,7 +269,19 @@ struct _reent
+     0, _NULL, _NULL, 0, _NULL, _NULL, 0, _NULL, { {0, _NULL, "", \
+     { 0,0,0,0,0,0,0,0}, 0, 1, \
+     {{_RAND48_SEED_0, _RAND48_SEED_1, _RAND48_SEED_2}, \
+-     {_RAND48_MULT_0, _RAND48_MULT_1, _RAND48_MULT_2}, _RAND48_ADD}} } }
++     {_RAND48_MULT_0, _RAND48_MULT_1, _RAND48_MULT_2}, _RAND48_ADD}, \
++     {0,{0}}, {0,{0}}, {0,{0}}, {0,{0}}, {0,{0}}, {0,{0}}, {0,{0}}, {0,{0}} \
++     } } }
++
++#define _REENT_MBLEN_STATE(ptr)	((ptr)->_new._reent._mblen_state)
++#define _REENT_MBTOWC_STATE(ptr)((ptr)->_new._reent._mbtowc_state)
++#define _REENT_WCTOMB_STATE(ptr)((ptr)->_new._reent._wctomb_state)
++#define _REENT_MBRLEN_STATE(ptr)((ptr)->_new._reent._mbrlen_state)
++#define _REENT_MBRTOWC_STATE(ptr)((ptr)->_new._reent._mbrtowc_state)
++#define _REENT_MBSRTOWCS_STATE(ptr)((ptr)->_new._reent._mbsrtowcs_state)
++#define _REENT_WCRTOMB_STATE(ptr)((ptr)->_new._reent._wcrtomb_state)
++#define _REENT_WCSRTOMBS_STATE(ptr)((ptr)->_new._reent._wcsrtombs_state)
++#define _REENT_CHECK_MISC(ptr)	        /* nothing */
+ 
+ /*
+  * All references to struct _reent are via this pointer.
+diff --git a/msys/rt/src/newlib/libc/include/wchar.h b/msys/rt/src/newlib/libc/include/wchar.h
+new file mode 100644
+index 0000000..a3be0ce
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/include/wchar.h
+@@ -0,0 +1,199 @@
++#ifndef _WCHAR_H_
++#define _WCHAR_H_
++
++#include <_ansi.h>
++
++#include <sys/reent.h>
++
++#define __need_size_t
++#define __need_wchar_t
++#define __need_wint_t
++#include <stddef.h>
++
++#define __need___va_list
++#include <stdarg.h>
++
++/* For _mbstate_t definition. */
++#include <sys/_types.h>
++
++/* For __STDC_ISO_10646__ */
++#include <sys/features.h>
++
++#ifndef NULL
++#define NULL	0
++#endif
++
++#ifndef WEOF
++# define WEOF ((wint_t)-1)
++#endif
++
++#ifndef WCHAR_MIN
++#define WCHAR_MIN 0
++#endif
++
++#ifndef WCHAR_MAX
++#ifdef __WCHAR_MAX__
++#define WCHAR_MAX __WCHAR_MAX__
++#else
++#define WCHAR_MAX 0x7fffffffu
++#endif
++#endif
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/* As required by POSIX.1-2008, declare tm as incomplete type.
++   The actual definition is in time.h. */
++struct tm;
++
++#ifndef _MBSTATE_T
++#define _MBSTATE_T
++typedef _mbstate_t mbstate_t;
++#endif /* _MBSTATE_T */
++
++wint_t	_EXFUN(btowc, (int));
++int	_EXFUN(wctob, (wint_t));
++size_t	_EXFUN(mbrlen, (const char * , size_t, mbstate_t *));
++size_t	_EXFUN(mbrtowc, (wchar_t * , const char * , size_t, mbstate_t *));
++size_t	_EXFUN(_mbrtowc_r, (struct _reent *, wchar_t * , const char * , 
++			size_t, mbstate_t *));
++int	_EXFUN(mbsinit, (const mbstate_t *));
++size_t	_EXFUN(mbsnrtowcs, (wchar_t * , const char ** , size_t, size_t,
++			mbstate_t *));
++size_t	_EXFUN(_mbsnrtowcs_r, (struct _reent *, wchar_t * , const char ** ,
++			size_t, size_t, mbstate_t *));
++size_t	_EXFUN(mbsrtowcs, (wchar_t * , const char ** , size_t, mbstate_t *));
++size_t	_EXFUN(_mbsrtowcs_r, (struct _reent *, wchar_t * , const char ** , size_t, mbstate_t *));
++size_t	_EXFUN(wcrtomb, (char * , wchar_t, mbstate_t *));
++size_t	_EXFUN(_wcrtomb_r, (struct _reent *, char * , wchar_t, mbstate_t *));
++size_t	_EXFUN(wcsnrtombs, (char * , const wchar_t ** , size_t, size_t,
++			mbstate_t *));
++size_t	_EXFUN(_wcsnrtombs_r, (struct _reent *, char * , const wchar_t ** , 
++			size_t, size_t, mbstate_t *));
++size_t	_EXFUN(wcsrtombs, (char * , const wchar_t ** , size_t, mbstate_t *));
++size_t	_EXFUN(_wcsrtombs_r, (struct _reent *, char * , const wchar_t ** , 
++			size_t, mbstate_t *));
++int	_EXFUN(wcscasecmp, (const wchar_t *, const wchar_t *));
++wchar_t	*_EXFUN(wcscat, (wchar_t * , const wchar_t *));
++wchar_t	*_EXFUN(wcschr, (const wchar_t *, wchar_t));
++int	_EXFUN(wcscmp, (const wchar_t *, const wchar_t *));
++int	_EXFUN(wcscoll, (const wchar_t *, const wchar_t *));
++wchar_t	*_EXFUN(wcscpy, (wchar_t * , const wchar_t *));
++wchar_t	*_EXFUN(wcpcpy, (wchar_t * , const wchar_t *));
++wchar_t	*_EXFUN(wcsdup, (const wchar_t *));
++wchar_t	*_EXFUN(_wcsdup_r, (struct _reent *, const wchar_t * ));
++size_t	_EXFUN(wcscspn, (const wchar_t *, const wchar_t *));
++size_t  _EXFUN(wcsftime, (wchar_t *, size_t, const wchar_t *, const struct tm *));
++size_t	_EXFUN(wcslcat, (wchar_t *, const wchar_t *, size_t));
++size_t	_EXFUN(wcslcpy, (wchar_t *, const wchar_t *, size_t));
++size_t	_EXFUN(wcslen, (const wchar_t *));
++int	_EXFUN(wcsncasecmp, (const wchar_t *, const wchar_t *, size_t));
++wchar_t	*_EXFUN(wcsncat, (wchar_t * , const wchar_t * , size_t));
++int	_EXFUN(wcsncmp, (const wchar_t *, const wchar_t *, size_t));
++wchar_t	*_EXFUN(wcsncpy, (wchar_t *  , const wchar_t * , size_t));
++wchar_t	*_EXFUN(wcpncpy, (wchar_t *  , const wchar_t * , size_t));
++size_t	_EXFUN(wcsnlen, (const wchar_t *, size_t));
++wchar_t	*_EXFUN(wcspbrk, (const wchar_t *, const wchar_t *));
++wchar_t	*_EXFUN(wcsrchr, (const wchar_t *, wchar_t));
++size_t	_EXFUN(wcsspn, (const wchar_t *, const wchar_t *));
++wchar_t	*_EXFUN(wcsstr, (const wchar_t *, const wchar_t *));
++wchar_t	*_EXFUN(wcstok, (wchar_t *, const wchar_t *, wchar_t **));
++double _EXFUN(wcstod, (const wchar_t *, wchar_t **));
++double _EXFUN(_wcstod_r, (struct _reent *, const wchar_t *, wchar_t **));
++float _EXFUN(wcstof, (const wchar_t *, wchar_t **));
++float _EXFUN(_wcstof_r, (struct _reent *, const wchar_t *, wchar_t **));
++int	_EXFUN(wcswidth, (const wchar_t *, size_t));
++size_t	_EXFUN(wcsxfrm, (wchar_t *, const wchar_t *, size_t));
++int	_EXFUN(wcwidth, (const wchar_t));
++wchar_t	*_EXFUN(wmemchr, (const wchar_t *, wchar_t, size_t));
++int	_EXFUN(wmemcmp, (const wchar_t *, const wchar_t *, size_t));
++wchar_t	*_EXFUN(wmemcpy, (wchar_t * , const wchar_t * , size_t));
++wchar_t	*_EXFUN(wmemmove, (wchar_t *, const wchar_t *, size_t));
++wchar_t	*_EXFUN(wmemset, (wchar_t *, wchar_t, size_t));
++
++long    _EXFUN(wcstol, (const wchar_t *, wchar_t **, int));
++long long _EXFUN(wcstoll, (const wchar_t *, wchar_t **, int));
++unsigned long _EXFUN(wcstoul, (const wchar_t *, wchar_t **, int));
++unsigned long long _EXFUN(wcstoull, (const wchar_t *, wchar_t **, int));
++long    _EXFUN(_wcstol_r, (struct _reent *, const wchar_t *, wchar_t **, int));
++long long _EXFUN(_wcstoll_r, (struct _reent *, const wchar_t *, wchar_t **, int));
++unsigned long _EXFUN(_wcstoul_r, (struct _reent *, const wchar_t *, wchar_t **, int));
++unsigned long long _EXFUN(_wcstoull_r, (struct _reent *, const wchar_t *, wchar_t **, int));
++
++wint_t _EXFUN(fgetwc, (__FILE *));
++wchar_t *_EXFUN(fgetws, (wchar_t *, int, __FILE *));
++wint_t _EXFUN(fputwc, (wchar_t, __FILE *));
++int _EXFUN(fputws, (const wchar_t *, __FILE *));
++int _EXFUN (fwide, (__FILE *, int));
++wint_t _EXFUN (getwc, (__FILE *));
++wint_t _EXFUN (getwchar, (void));
++wint_t _EXFUN(putwc, (wchar_t, __FILE *));
++wint_t _EXFUN(putwchar, (wchar_t));
++wint_t _EXFUN (ungetwc, (wint_t wc, __FILE *));
++
++wint_t _EXFUN(_fgetwc_r, (struct _reent *, __FILE *));
++wchar_t *_EXFUN(_fgetws_r, (struct _reent *, wchar_t *, int, __FILE *));
++wint_t _EXFUN(_fputwc_r, (struct _reent *, wchar_t, __FILE *));
++int _EXFUN(_fputws_r, (struct _reent *, const wchar_t *, __FILE *));
++int _EXFUN (_fwide_r, (struct _reent *, __FILE *, int));
++wint_t _EXFUN (_getwc_r, (struct _reent *, __FILE *));
++wint_t _EXFUN (_getwchar_r, (struct _reent *ptr));
++wint_t _EXFUN(_putwc_r, (struct _reent *, wchar_t, __FILE *));
++wint_t _EXFUN(_putwchar_r, (struct _reent *, wchar_t));
++wint_t _EXFUN (_ungetwc_r, (struct _reent *, wint_t wc, __FILE *));
++
++__FILE *_EXFUN (open_wmemstream, (wchar_t **, size_t *));
++__FILE *_EXFUN (_open_wmemstream_r, (struct _reent *, wchar_t **, size_t *));
++
++#ifndef __VALIST
++#ifdef __GNUC__
++#define __VALIST __gnuc_va_list
++#else
++#define __VALIST char*
++#endif
++#endif
++
++int	_EXFUN(fwprintf, (__FILE *, const wchar_t *, ...));
++int	_EXFUN(swprintf, (wchar_t *, size_t, const wchar_t *, ...));
++int	_EXFUN(vfwprintf, (__FILE *, const wchar_t *, __VALIST));
++int	_EXFUN(vswprintf, (wchar_t *, size_t, const wchar_t *, __VALIST));
++int	_EXFUN(vwprintf, (const wchar_t *, __VALIST));
++int	_EXFUN(wprintf, (const wchar_t *, ...));
++
++int	_EXFUN(_fwprintf_r, (struct _reent *, __FILE *, const wchar_t *, ...));
++int	_EXFUN(_swprintf_r, (struct _reent *, wchar_t *, size_t, const wchar_t *, ...));
++int	_EXFUN(_vfwprintf_r, (struct _reent *, __FILE *, const wchar_t *, __VALIST));
++int	_EXFUN(_vswprintf_r, (struct _reent *, wchar_t *, size_t, const wchar_t *, __VALIST));
++int	_EXFUN(_vwprintf_r, (struct _reent *, const wchar_t *, __VALIST));
++int	_EXFUN(_wprintf_r, (struct _reent *, const wchar_t *, ...));
++
++int	_EXFUN(fwscanf, (__FILE *, const wchar_t *, ...));
++int	_EXFUN(swscanf, (const wchar_t *, const wchar_t *, ...));
++int	_EXFUN(vfwscanf, (__FILE *, const wchar_t *, __VALIST));
++int	_EXFUN(vswscanf, (const wchar_t *, const wchar_t *, __VALIST));
++int	_EXFUN(vwscanf, (const wchar_t *, __VALIST));
++int	_EXFUN(wscanf, (const wchar_t *, ...));
++
++int	_EXFUN(_fwscanf_r, (struct _reent *, __FILE *, const wchar_t *, ...));
++int	_EXFUN(_swscanf_r, (struct _reent *, const wchar_t *, const wchar_t *, ...));
++int	_EXFUN(_vfwscanf_r, (struct _reent *, __FILE *, const wchar_t *, __VALIST));
++int	_EXFUN(_vswscanf_r, (struct _reent *, const wchar_t *, const wchar_t *, __VALIST));
++int	_EXFUN(_vwscanf_r, (struct _reent *, const wchar_t *, __VALIST));
++int	_EXFUN(_wscanf_r, (struct _reent *, const wchar_t *, ...));
++
++#define getwc(fp)	fgetwc(fp)
++#define putwc(wc,fp)	fputwc((wc), (fp))
++#ifndef _REENT_ONLY
++#define getwchar()	fgetwc(_REENT->_stdin)
++#define putwchar(wc)	fputwc((wc), _REENT->_stdout)
++#else
++#define getwchar()	fgetwc(_impure_ptr->_stdin)
++#define putwchar(wc)	fputwc((wc), _impure_ptr->_stdout)
++#endif
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* _WCHAR_H_ */
+diff --git a/msys/rt/src/newlib/libc/include/wctype.h b/msys/rt/src/newlib/libc/include/wctype.h
+new file mode 100644
+index 0000000..15aec00
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/include/wctype.h
+@@ -0,0 +1,51 @@
++#ifndef _WCTYPE_H_
++#define _WCTYPE_H_
++
++#include <_ansi.h>
++#include <sys/_types.h>
++
++#define __need_wint_t
++#include <stddef.h>
++
++#ifndef WEOF
++# define WEOF ((wint_t)-1)
++#endif
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#ifndef _WCTYPE_T
++#define _WCTYPE_T
++typedef int wctype_t;
++#endif
++
++#ifndef _WCTRANS_T
++#define _WCTRANS_T
++typedef int wctrans_t;
++#endif
++
++int	_EXFUN(iswalpha, (wint_t));
++int	_EXFUN(iswalnum, (wint_t));
++int	_EXFUN(iswblank, (wint_t));
++int	_EXFUN(iswcntrl, (wint_t));
++int	_EXFUN(iswctype, (wint_t, wctype_t));
++int	_EXFUN(iswdigit, (wint_t));
++int	_EXFUN(iswgraph, (wint_t));
++int	_EXFUN(iswlower, (wint_t));
++int	_EXFUN(iswprint, (wint_t));
++int	_EXFUN(iswpunct, (wint_t));
++int	_EXFUN(iswspace, (wint_t));
++int	_EXFUN(iswupper, (wint_t));
++int	_EXFUN(iswxdigit, (wint_t));
++wint_t	_EXFUN(towctrans, (wint_t, wctrans_t));
++wint_t	_EXFUN(towupper, (wint_t));
++wint_t	_EXFUN(towlower, (wint_t));
++wctrans_t _EXFUN(wctrans, (const char *));
++wctype_t _EXFUN(wctype, (const char *));
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* _WCTYPE_H_ */
+diff --git a/msys/rt/src/newlib/libc/locale/locale.c b/msys/rt/src/newlib/libc/locale/locale.c
+index e731c50..7464517 100644
+--- a/msys/rt/src/newlib/libc/locale/locale.c
++++ b/msys/rt/src/newlib/libc/locale/locale.c
+@@ -90,10 +90,12 @@ No supporting OS subroutines are required.
+ #include <limits.h>
+ #include <reent.h>
+ 
++#define MB_UTF8_MAX 4
++
+ #if defined (__CYGWIN__) || defined(__MSYS__)
+-int __declspec(dllexport) __mb_cur_max = 1;
++int __declspec(dllexport) __mb_cur_max = MB_UTF8_MAX;
+ #else
+-int __mb_cur_max = 1;
++int __mb_cur_max = MB_UTF8_MAX;
+ #endif
+ 
+ static _CONST struct lconv lconv = 
+@@ -133,7 +135,7 @@ _DEFUN(_setlocale_r, (p, category, locale),
+             {
+               strcpy (last_lc_ctype, lc_ctype);
+               strcpy (lc_ctype, locale);
+-              __mb_cur_max = 1;
++              __mb_cur_max = MB_UTF8_MAX;
+             }
+         }
+       else
+@@ -151,7 +153,7 @@ _DEFUN(_setlocale_r, (p, category, locale),
+           else if (strlen (locale) > 1)
+             __mb_cur_max = 2;
+           else
+-            __mb_cur_max = 1; 
++            __mb_cur_max = MB_UTF8_MAX; 
+         }
+       p->_current_category = category;  
+       p->_current_locale = locale;
+@@ -196,3 +198,9 @@ _DEFUN_VOID(localeconv)
+ }
+ 
+ #endif
++
++char *
++_DEFUN_VOID(__locale_charset)
++{
++  return "UTF-8";
++}
+diff --git a/msys/rt/src/newlib/libc/stdlib/Makefile.in b/msys/rt/src/newlib/libc/stdlib/Makefile.in
+index 6ca4b0f..c04f990 100644
+--- a/msys/rt/src/newlib/libc/stdlib/Makefile.in
++++ b/msys/rt/src/newlib/libc/stdlib/Makefile.in
+@@ -157,8 +157,17 @@ lib_a_SOURCES = \
+ 	valloc.c	\
+ 	wcstombs.c	\
+ 	wcstombs_r.c	\
++	wctob.c		\
+ 	wctomb.c	\
+-	wctomb_r.c
++	wctomb_r.c	\
++	mbrlen.c	\
++	mbrtowc.c	\
++	mbsinit.c	\
++	mbsnrtowcs.c	\
++	mbsrtowcs.c	\
++	wcrtomb.c	\
++	wcsnrtombs.c	\
++	wcsrtombs.c
+ 
+ 
+ lib_a_LIBADD = mallocr.o freer.o reallocr.o callocr.o cfreer.o malignr.o \
+@@ -230,7 +239,10 @@ mblen_r.o mbstowcs.o mbstowcs_r.o mbtowc.o mbtowc_r.o mlock.o mprec.o \
+ mrand48.o msize.o mstats.o mtrim.o nrand48.o putenv.o putenv_r.o \
+ qsort.o rand.o rand48.o rand_r.o realloc.o seed48.o setenv.o setenv_r.o \
+ srand48.o strdup.o strdup_r.o strtod.o strtol.o strtoul.o system.o \
+-valloc.o wcstombs.o wcstombs_r.o wctomb.o wctomb_r.o
++valloc.o wcstombs.o wcstombs_r.o wctob.o wctomb.o wctomb_r.o mbrlen.o \
++mbrtowc.o mbsinit.o mbsnrtowcs.o mbsrtowcs.o wcrtomb.o wcsnrtombs.o \
++wcsrtombs.o
++
+ CFLAGS = @CFLAGS@
+ COMPILE = $(CC) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+ CCLD = $(CC)
+diff --git a/msys/rt/src/newlib/libc/stdlib/local.h b/msys/rt/src/newlib/libc/stdlib/local.h
+index a274f20..4cfc128 100644
+--- a/msys/rt/src/newlib/libc/stdlib/local.h
++++ b/msys/rt/src/newlib/libc/stdlib/local.h
+@@ -5,4 +5,62 @@
+ 
+ char *	_EXFUN(_gcvt,(struct _reent *, double , int , char *, char, int));
+ 
++char *__locale_charset(_NOARGS);
++
++#ifndef __mbstate_t_defined
++#include <wchar.h>
++#endif
++
++extern int (*__wctomb) (struct _reent *, char *, wchar_t, const char *,
++			mbstate_t *);
++int __ascii_wctomb (struct _reent *, char *, wchar_t, const char *,
++		    mbstate_t *);
++#ifdef _MB_CAPABLE
++int __utf8_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++int __sjis_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++int __eucjp_wctomb (struct _reent *, char *, wchar_t, const char *,
++		    mbstate_t *);
++int __jis_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++int __iso_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++int __cp_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++#if defined(__CYGWIN__) || defined(__MSYS__)
++int __gbk_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++int __kr_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++int __big5_wctomb (struct _reent *, char *, wchar_t, const char *, mbstate_t *);
++#endif
++#endif
++
++extern int (*__mbtowc) (struct _reent *, wchar_t *, const char *, size_t,
++			const char *, mbstate_t *);
++int __ascii_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		    const char *, mbstate_t *);
++#ifdef _MB_CAPABLE
++int __utf8_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		   const char *, mbstate_t *);
++int __sjis_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		   const char *, mbstate_t *);
++int __eucjp_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		    const char *, mbstate_t *);
++int __jis_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		  const char *, mbstate_t *);
++int __iso_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		  const char *, mbstate_t *);
++int __cp_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		 const char *, mbstate_t *);
++#if defined(__CYGWIN__) || defined(__MSYS__)
++int __gbk_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		  const char *, mbstate_t *);
++int __kr_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		  const char *, mbstate_t *);
++int __big5_mbtowc (struct _reent *, wchar_t *, const char *, size_t,
++		 const char *, mbstate_t *);
++#endif
++#endif
++
++extern wchar_t __iso_8859_conv[14][0x60];
++int __iso_8859_index (const char *);
++
++extern wchar_t __cp_conv[][0x80];
++int __cp_index (const char *);
++
+ #endif
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbctype.h b/msys/rt/src/newlib/libc/stdlib/mbctype.h
+index 6abcf3d..65cf24c 100644
+--- a/msys/rt/src/newlib/libc/stdlib/mbctype.h
++++ b/msys/rt/src/newlib/libc/stdlib/mbctype.h
+@@ -14,7 +14,8 @@ int _EXFUN(_isjis, (int c));
+ 
+ #define _issjis1(c)    (((c) >= 0x81 && (c) <= 0x9f) || ((c) >= 0xe0 && (c) <= 0xef))
+ #define _issjis2(c)    (((c) >= 0x40 && (c) <= 0x7e) || ((c) >= 0x80 && (c) <= 0xfc))
+-#define _iseucjp(c)    ((c) >= 0xa1 && (c) <= 0xfe)
++#define _iseucjp1(c)   ((c) == 0x8e || (c) == 0x8f || ((c) >= 0xa1 && (c) <= 0xfe))
++#define _iseucjp2(c)   ((c) >= 0xa1 && (c) <= 0xfe)
+ #define _isjis(c)      ((c) >= 0x21 && (c) <= 0x7e)
+ 
+ #endif /* _MBCTYPE_H_ */
+diff --git a/msys/rt/src/newlib/libc/stdlib/mblen.c b/msys/rt/src/newlib/libc/stdlib/mblen.c
+index d9b774e..ace2388 100644
+--- a/msys/rt/src/newlib/libc/stdlib/mblen.c
++++ b/msys/rt/src/newlib/libc/stdlib/mblen.c
+@@ -16,20 +16,20 @@ TRAD_SYNOPSIS
+ 	size_t <[n]>;
+ 
+ DESCRIPTION
+-When MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
++When _MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
+ implementation of <<mblen>>.  In this case, the
+ only ``multi-byte character sequences'' recognized are single bytes,
+ and thus <<1>> is returned unless <[s]> is the null pointer or
+ has a length of 0 or is the empty string.
+ 
+-When MB_CAPABLE is defined, this routine calls <<_mbtowc_r>> to perform
++When _MB_CAPABLE is defined, this routine calls <<_mbtowc_r>> to perform
+ the conversion, passing a state variable to allow state dependent
+ decoding.  The result is based on the locale setting which may
+ be restricted to a defined set of locales.
+ 
+ RETURNS
+ This implementation of <<mblen>> returns <<0>> if
+-<[s]> is <<NULL>> or the empty string; it returns <<1>> if not MB_CAPABLE or
++<[s]> is <<NULL>> or the empty string; it returns <<1>> if not _MB_CAPABLE or
+ the character is a single-byte character; it returns <<-1>>
+ if the multi-byte character is invalid; otherwise it returns
+ the number of bytes in the multibyte character.
+@@ -43,24 +43,38 @@ effects vary with the locale.
+ 
+ #ifndef _REENT_ONLY
+ 
++#include <newlib.h>
+ #include <stdlib.h>
++#include <wchar.h>
++#include "local.h"
+ 
+ int
+ _DEFUN (mblen, (s, n), 
+         const char *s _AND
+         size_t n)
+ {
+-#ifdef MB_CAPABLE
+-        static int state;
+-
+-        return _mbtowc_r (_REENT, NULL, s, n, &state);
+-#else /* not MB_CAPABLE */
+-        if (s == NULL || *s == '\0')
+-                return 0;
+-        if (n == 0)
+-                return -1;
+-        return 1;
+-#endif /* not MB_CAPABLE */
++#ifdef _MB_CAPABLE
++  int retval = 0;
++  mbstate_t *state;
++  
++  _REENT_CHECK_MISC(_REENT);
++  state = &(_REENT_MBLEN_STATE(_REENT));
++  retval = __mbtowc (_REENT, NULL, s, n, __locale_charset (), state);
++  if (retval < 0)
++    {
++      state->__count = 0;
++      return -1;
++    }
++  else
++    return retval;
++  
++#else /* not _MB_CAPABLE */
++  if (s == NULL || *s == '\0')
++    return 0;
++  if (n == 0)
++    return -1;
++  return 1;
++#endif /* not _MB_CAPABLE */
+ }
+ 
+ #endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/mblen_r.c b/msys/rt/src/newlib/libc/stdlib/mblen_r.c
+index 22d1d40..c3b5964 100644
+--- a/msys/rt/src/newlib/libc/stdlib/mblen_r.c
++++ b/msys/rt/src/newlib/libc/stdlib/mblen_r.c
+@@ -18,20 +18,20 @@ TRAD_SYNOPSIS
+         int *<[state]>;
+ 
+ DESCRIPTION
+-When MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
++When _MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
+ implementation of <<_mblen_r>>.  In this case, the
+ only ``multi-byte character sequences'' recognized are single bytes,
+ and thus <<1>> is returned unless <[s]> is the null pointer or
+ has a length of 0 or is the empty string.
+ 
+-When MB_CAPABLE is defined, this routine calls <<_mbtowc_r>> to perform
++When _MB_CAPABLE is defined, this routine calls <<_mbtowc_r>> to perform
+ the conversion, passing a state variable to allow state dependent
+ decoding.  The result is based on the locale setting which may
+ be restricted to a defined set of locales.
+ 
+ RETURNS
+ This implementation of <<_mblen_r>> returns <<0>> if
+-<[s]> is <<NULL>> or the empty string; it returns <<1>> if not MB_CAPABLE or
++<[s]> is <<NULL>> or the empty string; it returns <<1>> if not _MB_CAPABLE or
+ the character is a single-byte character; it returns <<-1>>
+ if the multi-byte character is invalid; otherwise it returns
+ the number of bytes in the multibyte character.
+@@ -43,24 +43,35 @@ effects vary with the locale.
+ <<_mblen_r>> requires no supporting OS subroutines.
+ */
+ 
++#include <newlib.h>
+ #include <stdlib.h>
++#include <wchar.h>
++#include "local.h"
+ 
+ int
+ _DEFUN (_mblen_r, (r, s, n, state), 
+         struct _reent *r    _AND
+         const char *s _AND
+         size_t n _AND
+-        int *state)
++        mbstate_t *state)
+ {
+-#ifdef MB_CAPABLE
++#ifdef _MB_CAPABLE
++  int retval;
++  retval = __mbtowc (r, NULL, s, n, __locale_charset (), state);
+ 
+-        return _mbtowc_r (r, NULL, s, n, state);
+-#else /* not MB_CAPABLE */
+-        if (s == NULL || *s == '\0')
+-                return 0;
+-        if (n == 0)
+-                return -1;
+-        return 1;
+-#endif /* not MB_CAPABLE */
++  if (retval < 0)
++    {
++      state->__count = 0;
++      return -1;
++    }
++
++  return retval;
++#else /* not _MB_CAPABLE */
++  if (s == NULL || *s == '\0')
++    return 0;
++  if (n == 0)
++    return -1;
++  return 1;
++#endif /* not _MB_CAPABLE */
+ }
+ 
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbrlen.c b/msys/rt/src/newlib/libc/stdlib/mbrlen.c
+new file mode 100644
+index 0000000..ac9aa32
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/mbrlen.c
+@@ -0,0 +1,20 @@
++#include <reent.h>
++#include <newlib.h>
++#include <wchar.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <errno.h>
++
++size_t
++mbrlen(const char *s, size_t n, mbstate_t *ps)
++{
++#ifdef _MB_CAPABLE
++  if (ps == NULL)
++    {
++      _REENT_CHECK_MISC(_REENT);
++      ps = &(_REENT_MBRLEN_STATE(_REENT));
++    }
++#endif
++
++  return mbrtowc(NULL, s, n, ps);
++}
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbrtowc.c b/msys/rt/src/newlib/libc/stdlib/mbrtowc.c
+new file mode 100644
+index 0000000..e191e11
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/mbrtowc.c
+@@ -0,0 +1,79 @@
++#include <reent.h>
++#include <newlib.h>
++#include <wchar.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <errno.h>
++#include <string.h>
++#include "local.h"
++
++size_t
++_DEFUN (_mbrtowc_r, (ptr, pwc, s, n, ps),
++	struct _reent *ptr _AND
++	wchar_t *pwc _AND
++	const char *s _AND
++	size_t n _AND
++	mbstate_t *ps)
++{
++  int retval = 0;
++
++#ifdef _MB_CAPABLE
++  if (ps == NULL)
++    {
++      _REENT_CHECK_MISC(ptr);
++      ps = &(_REENT_MBRTOWC_STATE(ptr));
++    }
++#endif
++
++  if (s == NULL)
++    retval = __mbtowc (ptr, NULL, "", 1, __locale_charset (), ps);
++  else
++    retval = __mbtowc (ptr, pwc, s, n, __locale_charset (), ps);
++
++  if (retval == -1)
++    {
++      ps->__count = 0;
++      ptr->_errno = EILSEQ;
++      return (size_t)(-1);
++    }
++  else
++    return (size_t)retval;
++}
++
++#ifndef _REENT_ONLY
++size_t
++_DEFUN (mbrtowc, (pwc, s, n, ps),
++	wchar_t *pwc _AND
++	const char *s _AND
++	size_t n _AND
++	mbstate_t *ps)
++{
++#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++  return _mbrtowc_r (_REENT, pwc, s, n, ps);
++#else
++  int retval = 0;
++
++#ifdef _MB_CAPABLE
++  if (ps == NULL)
++    {
++      _REENT_CHECK_MISC(_REENT);
++      ps = &(_REENT_MBRTOWC_STATE(_REENT));
++    }
++#endif
++
++  if (s == NULL)
++    retval = __mbtowc (_REENT, NULL, "", 1, __locale_charset (), ps);
++  else
++    retval = __mbtowc (_REENT, pwc, s, n, __locale_charset (), ps);
++
++  if (retval == -1)
++    {
++      ps->__count = 0;
++      _REENT->_errno = EILSEQ;
++      return (size_t)(-1);
++    }
++  else
++    return (size_t)retval;
++#endif /* not PREFER_SIZE_OVER_SPEED */
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbsinit.c b/msys/rt/src/newlib/libc/stdlib/mbsinit.c
+new file mode 100644
+index 0000000..e32369a
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/mbsinit.c
+@@ -0,0 +1,14 @@
++#include <reent.h>
++#include <wchar.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <errno.h>
++
++int
++mbsinit(const mbstate_t *ps)
++{
++  if (ps == NULL || ps->__count == 0)
++    return 1;
++  else
++    return 0;
++}
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbsnrtowcs.c b/msys/rt/src/newlib/libc/stdlib/mbsnrtowcs.c
+new file mode 100644
+index 0000000..6729df9
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/mbsnrtowcs.c
+@@ -0,0 +1,179 @@
++/*
++FUNCTION
++<<mbsrtowcs>>, <<mbsnrtowcs>>---convert a character string to a wide-character string
++
++INDEX
++	mbsrtowcs
++INDEX
++	_mbsrtowcs_r
++INDEX
++	mbsnrtowcs
++INDEX
++	_mbsnrtowcs_r
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	size_t mbsrtowcs(wchar_t *<[dst]>, const char **<[src]>, size_t <[len]>,
++			 mbstate_t *<[ps]>);
++
++	#include <wchar.h>
++	size_t _mbsrtowcs_r(struct _reent *<[ptr]>, wchar_t *<[dst]>,
++			    const char **<[src]>, size_t <[len]>,
++			    mbstate_t *<[ps]>);
++
++	#include <wchar.h>
++	size_t mbsnrtowcs(wchar_t *<[dst]>, const char **<[src]>,
++			  size_t <[nms]>, size_t <[len]>, mbstate_t *<[ps]>);
++
++	#include <wchar.h>
++	size_t _mbsnrtowcs_r(struct _reent *<[ptr]>, wchar_t *<[dst]>,
++			     const char **<[src]>, size_t <[nms]>,
++			     size_t <[len]>, mbstate_t *<[ps]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	size_t mbsrtowcs(<[dst]>, <[src]>, <[len]>, <[ps]>)
++	wchar_t *<[dst]>;
++	const char **<[src]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++	#include <wchar.h>
++	size_t _mbsrtowcs_r(<[ptr]>, <[dst]>, <[src]>, <[len]>, <[ps]>)
++	struct _reent *<[ptr]>;
++	wchar_t *<[dst]>;
++	const char **<[src]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++	#include <wchar.h>
++	size_t mbsnrtowcs(<[dst]>, <[src]>, <[nms]>, <[len]>, <[ps]>)
++	wchar_t *<[dst]>;
++	const char **<[src]>;
++	size_t <[nms]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++	#include <wchar.h>
++	size_t _mbsnrtowcs_r(<[ptr]>, <[dst]>, <[src]>, <[nms]>, <[len]>, <[ps]>)
++	struct _reent *<[ptr]>;
++	wchar_t *<[dst]>;
++	const char **<[src]>;
++	size_t <[nms]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++DESCRIPTION
++The <<mbsrtowcs>> function converts a sequence of multibyte characters
++pointed to indirectly by <[src]> into a sequence of corresponding wide
++characters and stores at most <[len]> of them in the wchar_t array pointed
++to by <[dst]>, until it encounters a terminating null character ('\0').
++
++If <[dst]> is NULL, no characters are stored.
++
++If <[dst]> is not NULL, the pointer pointed to by <[src]> is updated to point
++to the character after the one that conversion stopped at.  If conversion
++stops because a null character is encountered, *<[src]> is set to NULL.
++
++The mbstate_t argument, <[ps]>, is used to keep track of the shift state.  If
++it is NULL, <<mbsrtowcs>> uses an internal, static mbstate_t object, which
++is initialized to the initial conversion state at program startup.
++
++The <<mbsnrtowcs>> function behaves identically to <<mbsrtowcs>>, except that
++conversion stops after reading at most <[nms]> bytes from the buffer pointed
++to by <[src]>.
++
++RETURNS
++The <<mbsrtowcs>> and <<mbsnrtowcs>> functions return the number of wide
++characters stored in the array pointed to by <[dst]> if successful, otherwise
++it returns (size_t)-1.
++
++PORTABILITY
++<<mbsrtowcs>> is defined by the C99 standard.
++<<mbsnrtowcs>> is defined by the POSIX.1-2008 standard.
++*/
++
++#include <reent.h>
++#include <newlib.h>
++#include <wchar.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <errno.h>
++
++size_t
++_DEFUN (_mbsnrtowcs_r, (r, dst, src, nms, len, ps), 
++	struct _reent *r _AND
++	wchar_t *dst _AND
++	const char **src _AND
++	size_t nms _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  wchar_t *ptr = dst;
++  const char *tmp_src;
++  size_t max;
++  size_t count = 0;
++  int bytes;
++
++#ifdef _MB_CAPABLE
++  if (ps == NULL)
++    {
++      _REENT_CHECK_MISC(r);
++      ps = &(_REENT_MBSRTOWCS_STATE(r));
++    }
++#endif
++
++  if (dst == NULL)
++    {
++      /* Ignore original len value and do not alter src pointer if the
++         dst pointer is NULL.  */
++      len = (size_t)-1;
++      tmp_src = *src;
++      src = &tmp_src;
++    }      
++  
++  max = len;
++  while (len > 0)
++    {
++      bytes = _mbrtowc_r (r, ptr, *src, nms, ps);
++      if (bytes > 0)
++	{
++	  *src += bytes;
++	  nms -= bytes;
++	  ++count;
++	  ptr = (dst == NULL) ? NULL : ptr + 1;
++	  --len;
++	}
++      else if (bytes == -2)
++	{
++	  *src += nms;
++	  return count;
++	}
++      else if (bytes == 0)
++	{
++	  *src = NULL;
++	  return count;
++	}
++      else
++	{
++	  ps->__count = 0;
++	  r->_errno = EILSEQ;
++	  return (size_t)-1;
++	}
++    }
++
++  return (size_t)max;
++}
++
++#ifndef _REENT_ONLY
++size_t
++_DEFUN (mbsnrtowcs, (dst, src, nms, len, ps),
++	wchar_t *dst _AND
++	const char **src _AND
++	size_t nms _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  return _mbsnrtowcs_r (_REENT, dst, src, nms, len, ps);
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbsrtowcs.c b/msys/rt/src/newlib/libc/stdlib/mbsrtowcs.c
+new file mode 100644
+index 0000000..d5137d1
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/mbsrtowcs.c
+@@ -0,0 +1,29 @@
++#include <reent.h>
++#include <newlib.h>
++#include <wchar.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <errno.h>
++
++size_t
++_DEFUN (_mbsrtowcs_r, (r, dst, src, len, ps), 
++	struct _reent *r _AND
++	wchar_t *dst _AND
++	const char **src _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  return _mbsnrtowcs_r (r, dst, src, (size_t) -1, len, ps);
++}
++
++#ifndef _REENT_ONLY
++size_t
++_DEFUN (mbsrtowcs, (dst, src, len, ps),
++	wchar_t *dst _AND
++	const char **src _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  return _mbsnrtowcs_r (_REENT, dst, src, (size_t) -1, len, ps);
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbstowcs.c b/msys/rt/src/newlib/libc/stdlib/mbstowcs.c
+index fee621a..334b5f5 100644
+--- a/msys/rt/src/newlib/libc/stdlib/mbstowcs.c
++++ b/msys/rt/src/newlib/libc/stdlib/mbstowcs.c
+@@ -17,13 +17,13 @@ TRAD_SYNOPSIS
+ 	size_t <[n]>;
+ 
+ DESCRIPTION
+-When MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
++When _MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
+ implementation of <<mbstowcs>>.  In this case, the
+ only ``multi-byte character sequences'' recognized are single bytes,
+ and they are ``converted'' to wide-char versions simply by byte
+ extension.
+ 
+-When MB_CAPABLE is defined, this routine calls <<_mbstowcs_r>> to perform
++When _MB_CAPABLE is defined, this routine calls <<_mbstowcs_r>> to perform
+ the conversion, passing a state variable to allow state dependent
+ decoding.  The result is based on the locale setting which may
+ be restricted to a defined set of locales.
+@@ -31,7 +31,7 @@ be restricted to a defined set of locales.
+ RETURNS
+ This implementation of <<mbstowcs>> returns <<0>> if
+ <[s]> is <<NULL>> or is the empty string; 
+-it returns <<-1>> if MB_CAPABLE and one of the
++it returns <<-1>> if _MB_CAPABLE and one of the
+ multi-byte characters is invalid or incomplete;
+ otherwise it returns the minimum of: <<n>> or the
+ number of multi-byte characters in <<s>> plus 1 (to
+@@ -49,7 +49,9 @@ effects vary with the locale.
+ 
+ #ifndef _REENT_ONLY
+ 
++#include <newlib.h>
+ #include <stdlib.h>
++#include <wchar.h>
+ 
+ size_t
+ _DEFUN (mbstowcs, (pwcs, s, n),
+@@ -57,24 +59,25 @@ _DEFUN (mbstowcs, (pwcs, s, n),
+         const char *s _AND
+         size_t n)
+ {
+-#ifdef MB_CAPABLE
+-        int state = 0;
+-
+-        return _mbstowcs_r (_REENT, pwcs, s, n, &state);
+-#else /* not MB_CAPABLE */
+-
+-        int count = 0;
+-
+-        if (n != 0) {
+-                do {
+-                        if ((*pwcs++ = (wchar_t) *s++) == 0)
+-                                break;
+-                        count++;
+-                } while (--n != 0);
+-        }
+-
+-        return count;
+-#endif /* not MB_CAPABLE */
++#ifdef _MB_CAPABLE
++  mbstate_t state;
++  state.__count = 0;
++  
++  return _mbstowcs_r (_REENT, pwcs, s, n, &state);
++#else /* not _MB_CAPABLE */
++  
++  int count = 0;
++  
++  if (n != 0) {
++    do {
++      if ((*pwcs++ = (wchar_t) *s++) == 0)
++	break;
++      count++;
++    } while (--n != 0);
++  }
++  
++  return count;
++#endif /* not _MB_CAPABLE */
+ }
+ 
+ #endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbstowcs_r.c b/msys/rt/src/newlib/libc/stdlib/mbstowcs_r.c
+index 5478849..3ba8677 100644
+--- a/msys/rt/src/newlib/libc/stdlib/mbstowcs_r.c
++++ b/msys/rt/src/newlib/libc/stdlib/mbstowcs_r.c
+@@ -1,4 +1,6 @@
+ #include <stdlib.h>
++#include <wchar.h>
++#include "local.h"
+ 
+ size_t
+ _DEFUN (_mbstowcs_r, (reent, pwcs, s, n, state),
+@@ -6,24 +8,31 @@ _DEFUN (_mbstowcs_r, (reent, pwcs, s, n, state),
+         wchar_t       *pwcs _AND
+         const char    *s    _AND
+         size_t         n    _AND
+-        int           *state)
++        mbstate_t     *state)
+ {
+-  wchar_t *ptr = pwcs;
+-  size_t max = n;
++  size_t ret = 0;
+   char *t = (char *)s;
+   int bytes;
+ 
++  if (!pwcs)
++    n = (size_t) 1; /* Value doesn't matter as long as it's not 0. */
+   while (n > 0)
+     {
+-      bytes = _mbtowc_r (r, ptr, t, MB_CUR_MAX, state);
+-      if (bytes == -1)
+-        return -1;
++      bytes = __mbtowc (r, pwcs, t, MB_CUR_MAX, __locale_charset (), state);
++      if (bytes < 0)
++	{
++	  state->__count = 0;
++	  return -1;
++	}
+       else if (bytes == 0)
+-        return ptr - pwcs;
++	break;
+       t += bytes;
+-      ++ptr;
+-      --n;
++      ++ret;
++      if (pwcs)
++	{
++	  ++pwcs;
++	  --n;
++	}
+     }
+-
+-  return max;
++  return ret;
+ }   
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbtowc.c b/msys/rt/src/newlib/libc/stdlib/mbtowc.c
+index 5e34fe3..83b6a0e 100644
+--- a/msys/rt/src/newlib/libc/stdlib/mbtowc.c
++++ b/msys/rt/src/newlib/libc/stdlib/mbtowc.c
+@@ -17,7 +17,7 @@ TRAD_SYNOPSIS
+ 	size_t <[n]>;
+ 
+ DESCRIPTION
+-When MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
++When _MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
+ implementation of <<mbtowc>>.  In this case,
+ only ``multi-byte character sequences'' recognized are single bytes,
+ and they are ``converted'' to themselves.
+@@ -25,7 +25,7 @@ Each call to <<mbtowc>> copies one character from <<*<[s]>>> to
+ <<*<[pwc]>>>, unless <[s]> is a null pointer.  The argument n
+ is ignored.
+ 
+-When MB_CAPABLE is defined, this routine calls <<_mbtowc_r>> to perform
++When _MB_CAPABLE is defined, this routine calls <<_mbtowc_r>> to perform
+ the conversion, passing a state variable to allow state dependent
+ decoding.  The result is based on the locale setting which may
+ be restricted to a defined set of locales.
+@@ -33,7 +33,7 @@ be restricted to a defined set of locales.
+ RETURNS
+ This implementation of <<mbtowc>> returns <<0>> if
+ <[s]> is <<NULL>> or is the empty string; 
+-it returns <<1>> if not MB_CAPABLE or
++it returns <<1>> if not _MB_CAPABLE or
+ the character is a single-byte character; it returns <<-1>>
+ if n is <<0>> or the multi-byte character is invalid; 
+ otherwise it returns the number of bytes in the multibyte character.
+@@ -51,7 +51,10 @@ effects vary with the locale.
+ 
+ #ifndef _REENT_ONLY
+ 
++#include <newlib.h>
+ #include <stdlib.h>
++#include <wchar.h>
++#include "local.h"
+ 
+ int
+ _DEFUN (mbtowc, (pwc, s, n),
+@@ -59,19 +62,30 @@ _DEFUN (mbtowc, (pwc, s, n),
+         const char *s _AND
+         size_t n)
+ {
+-#ifdef MB_CAPABLE
+-        static int state;
+-
+-        return _mbtowc_r (_REENT, pwc, s, n, &state);
+-#else /* not MB_CAPABLE */
+-        if (s == NULL)
+-                return 0;
+-        if (n == 0)
+-                return -1;
+-        if (pwc)
+-                *pwc = (wchar_t) *s;
+-        return (*s != '\0');
+-#endif /* not MB_CAPABLE */
++#ifdef _MB_CAPABLE
++  int retval = 0;
++  mbstate_t *ps;
++
++  _REENT_CHECK_MISC(_REENT);
++  ps = &(_REENT_MBTOWC_STATE(_REENT));
++  
++  retval = __mbtowc (_REENT, pwc, s, n, __locale_charset (), ps);
++  
++  if (retval < 0)
++    {
++      ps->__count = 0;
++      return -1;
++    }
++  return retval;
++#else /* not _MB_CAPABLE */
++  if (s == NULL)
++    return 0;
++  if (n == 0)
++    return -1;
++  if (pwc)
++    *pwc = (wchar_t) *s;
++  return (*s != '\0');
++#endif /* not _MB_CAPABLE */
+ }
+ 
+ #endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/mbtowc_r.c b/msys/rt/src/newlib/libc/stdlib/mbtowc_r.c
+index 4bf3023..9e81a10 100644
+--- a/msys/rt/src/newlib/libc/stdlib/mbtowc_r.c
++++ b/msys/rt/src/newlib/libc/stdlib/mbtowc_r.c
+@@ -1,13 +1,75 @@
++#include <newlib.h>
+ #include <stdlib.h>
+ #include <locale.h>
+ #include "mbctype.h"
++#include <wchar.h>
++#include <string.h>
++#include <errno.h>
++#include "local.h"
+ 
+-#ifdef MB_CAPABLE
++int (*__mbtowc) (struct _reent *, wchar_t *, const char *, size_t,
++		 const char *, mbstate_t *)
++#if defined(__CYGWIN__) || defined(__MSYS__)
++   /* Cygwin starts up in UTF-8 mode. */
++   = __utf8_mbtowc;
++#else
++   = __ascii_mbtowc;
++#endif
++
++int
++_DEFUN (_mbtowc_r, (r, pwc, s, n, state),
++        struct _reent *r   _AND
++        wchar_t       *pwc _AND 
++        const char    *s   _AND        
++        size_t         n   _AND
++        mbstate_t      *state)
++{
++  return __mbtowc (r, pwc, s, n, __locale_charset (), state);
++}
++
++int
++_DEFUN (__ascii_mbtowc, (r, pwc, s, n, charset, state),
++        struct _reent *r       _AND
++        wchar_t       *pwc     _AND 
++        const char    *s       _AND        
++        size_t         n       _AND
++	const char    *charset _AND
++        mbstate_t      *state)
++{
++  wchar_t dummy;
++  unsigned char *t = (unsigned char *)s;
++
++  if (pwc == NULL)
++    pwc = &dummy;
++
++  if (s == NULL)
++    return 0;
++
++  if (n == 0)
++    return -2;
++
++#if defined(__CYGWIN__) || defined(__MSYS__)
++  if ((wchar_t)*t >= 0x80)
++    {
++      r->_errno = EILSEQ;
++      return -1;
++    }
++#endif
++
++  *pwc = (wchar_t)*t;
++  
++  if (*t == '\0')
++    return 0;
++
++  return 1;
++}
++
++#ifdef _MB_CAPABLE
+ typedef enum { ESCAPE, DOLLAR, BRACKET, AT, B, J, 
+                NUL, JIS_CHAR, OTHER, JIS_C_NUM } JIS_CHAR_TYPE;
+-typedef enum { ASCII, A_ESC, A_ESC_DL, JIS, JIS_1, JIS_2, J_ESC, J_ESC_BR,
+-               J2_ESC, J2_ESC_BR, DONE, INV, JIS_S_NUM } JIS_STATE; 
+-typedef enum { COPY_A, COPY_J, COPY_J2, MAKE_A, MAKE_J, NOOP, EMPTY, ERROR } JIS_ACTION;
++typedef enum { ASCII, JIS, A_ESC, A_ESC_DL, JIS_1, J_ESC, J_ESC_BR,
++               INV, JIS_S_NUM } JIS_STATE; 
++typedef enum { COPY_A, COPY_J1, COPY_J2, MAKE_A, NOOP, EMPTY, ERROR } JIS_ACTION;
+ 
+ /************************************************************************************** 
+  * state/action tables for processing JIS encoding
+@@ -18,40 +80,38 @@ typedef enum { COPY_A, COPY_J, COPY_J2, MAKE_A, MAKE_J, NOOP, EMPTY, ERROR } JIS
+ 
+ static JIS_STATE JIS_state_table[JIS_S_NUM][JIS_C_NUM] = {
+ /*              ESCAPE   DOLLAR    BRACKET   AT       B       J        NUL      JIS_CHAR  OTHER */
+-/* ASCII */   { A_ESC,   DONE,     DONE,     DONE,    DONE,   DONE,    DONE,    DONE,     DONE },
+-/* A_ESC */   { DONE,    A_ESC_DL, DONE,     DONE,    DONE,   DONE,    DONE,    DONE,     DONE },
+-/* A_ESC_DL */{ DONE,    DONE,     DONE,     JIS,     JIS,    DONE,    DONE,    DONE,     DONE }, 
++/* ASCII */   { A_ESC,   ASCII,    ASCII,    ASCII,   ASCII,  ASCII,   ASCII,   ASCII,    ASCII },
+ /* JIS */     { J_ESC,   JIS_1,    JIS_1,    JIS_1,   JIS_1,  JIS_1,   INV,     JIS_1,    INV },
+-/* JIS_1 */   { INV,     JIS_2,    JIS_2,    JIS_2,   JIS_2,  JIS_2,   INV,     JIS_2,    INV },
+-/* JIS_2 */   { J2_ESC,  DONE,     DONE,     DONE,    DONE,   DONE,    INV,     DONE,     DONE },
++/* A_ESC */   { ASCII,   A_ESC_DL, ASCII,    ASCII,   ASCII,  ASCII,   ASCII,   ASCII,    ASCII },
++/* A_ESC_DL */{ ASCII,   ASCII,    ASCII,    JIS,     JIS,    ASCII,   ASCII,   ASCII,    ASCII }, 
++/* JIS_1 */   { INV,     JIS,      JIS,      JIS,     JIS,    JIS,     INV,     JIS,      INV },
+ /* J_ESC */   { INV,     INV,      J_ESC_BR, INV,     INV,    INV,     INV,     INV,      INV },
+ /* J_ESC_BR */{ INV,     INV,      INV,      INV,     ASCII,  ASCII,   INV,     INV,      INV },
+-/* J2_ESC */  { INV,     INV,      J2_ESC_BR,INV,     INV,    INV,     INV,     INV,      INV },
+-/* J2_ESC_BR*/{ INV,     INV,      INV,      INV,     DONE,   DONE,    INV,     INV,      INV },
+ };
+ 
+ static JIS_ACTION JIS_action_table[JIS_S_NUM][JIS_C_NUM] = {
+ /*              ESCAPE   DOLLAR    BRACKET   AT       B        J        NUL      JIS_CHAR  OTHER */
+ /* ASCII */   { NOOP,    COPY_A,   COPY_A,   COPY_A,  COPY_A,  COPY_A,  EMPTY,   COPY_A,  COPY_A},
++/* JIS */     { NOOP,    COPY_J1,  COPY_J1,  COPY_J1, COPY_J1, COPY_J1, ERROR,   COPY_J1, ERROR },
+ /* A_ESC */   { COPY_A,  NOOP,     COPY_A,   COPY_A,  COPY_A,  COPY_A,  COPY_A,  COPY_A,  COPY_A},
+-/* A_ESC_DL */{ COPY_A,  COPY_A,   COPY_A,   MAKE_J,  MAKE_J,  COPY_A,  COPY_A,  COPY_A,  COPY_A},
+-/* JIS */     { NOOP,    NOOP,     NOOP,     NOOP,    NOOP,    NOOP,    ERROR,   NOOP,    ERROR },
+-/* JIS_1 */   { ERROR,   NOOP,     NOOP,     NOOP,    NOOP,    NOOP,    ERROR,   NOOP,    ERROR },
+-/* JIS_2 */   { NOOP,    COPY_J2,  COPY_J2,  COPY_J2, COPY_J2, COPY_J2, ERROR,   COPY_J2, COPY_J2},
++/* A_ESC_DL */{ COPY_A,  COPY_A,   COPY_A,   NOOP,    NOOP,    COPY_A,  COPY_A,  COPY_A,  COPY_A},
++/* JIS_1 */   { ERROR,   COPY_J2,  COPY_J2,  COPY_J2, COPY_J2, COPY_J2, ERROR,   COPY_J2, ERROR },
+ /* J_ESC */   { ERROR,   ERROR,    NOOP,     ERROR,   ERROR,   ERROR,   ERROR,   ERROR,   ERROR },
+-/* J_ESC_BR */{ ERROR,   ERROR,    ERROR,    ERROR,   NOOP,    NOOP,    ERROR,   ERROR,   ERROR },
+-/* J2_ESC */  { ERROR,   ERROR,    NOOP,     ERROR,   ERROR,   ERROR,   ERROR,   ERROR,   ERROR },
+-/* J2_ESC_BR*/{ ERROR,   ERROR,    ERROR,    ERROR,   COPY_J,  COPY_J,  ERROR,   ERROR,   ERROR },
++/* J_ESC_BR */{ ERROR,   ERROR,    ERROR,    ERROR,   MAKE_A,  MAKE_A,  ERROR,   ERROR,   ERROR },
+ };
+-#endif /* MB_CAPABLE */
+ 
++/* we override the mbstate_t __count field for more complex encodings and use it store a state value */
++#define __state __count
++
++#ifdef _MB_EXTENDED_CHARSETS_ISO
+ int
+-_DEFUN (_mbtowc_r, (r, pwc, s, n, state),
+-        struct _reent *r   _AND
+-        wchar_t       *pwc _AND 
+-        const char    *s   _AND        
+-        size_t         n   _AND
+-        int           *state)
++_DEFUN (__iso_mbtowc, (r, pwc, s, n, charset, state),
++        struct _reent *r       _AND
++        wchar_t       *pwc     _AND 
++        const char    *s       _AND        
++        size_t         n       _AND
++	const char    *charset _AND
++        mbstate_t      *state)
+ {
+   wchar_t dummy;
+   unsigned char *t = (unsigned char *)s;
+@@ -59,145 +119,419 @@ _DEFUN (_mbtowc_r, (r, pwc, s, n, state),
+   if (pwc == NULL)
+     pwc = &dummy;
+ 
+-  if (s != NULL && n == 0)
+-    return -1;
++  if (s == NULL)
++    return 0;
++
++  if (n == 0)
++    return -2;
+ 
+-#ifdef MB_CAPABLE
+-  if (r->_current_locale == NULL ||
+-      (strlen (r->_current_locale) <= 1))
+-    { /* fall-through */ }
+-  else if (!strcmp (r->_current_locale, "C-SJIS"))
++  if (*t >= 0xa0)
+     {
+-      int char1;
+-      if (s == NULL)
+-        return 0;  /* not state-dependent */
+-      char1 = *t;
+-      if (_issjis1 (char1))
+-        {
+-          int char2 = t[1];
+-          if (n <= 1)
+-            return -1;
+-          if (_issjis2 (char2))
+-            {
+-              *pwc = (((wchar_t)*t) << 8) + (wchar_t)(*(t+1));
+-              return 2;
+-            }
+-          else  
+-            return -1;
+-        }
++      int iso_idx = __iso_8859_index (charset + 9);
++      if (iso_idx >= 0)
++	{
++	  *pwc = __iso_8859_conv[iso_idx][*t - 0xa0];
++	  if (*pwc == 0) /* Invalid character */
++	    {
++	      r->_errno = EILSEQ;
++	      return -1;
++	    }
++	  return 1;
++	}
+     }
+-  else if (!strcmp (r->_current_locale, "C-EUCJP"))
++
++  *pwc = (wchar_t) *t;
++  
++  if (*t == '\0')
++    return 0;
++
++  return 1;
++}
++#endif /* _MB_EXTENDED_CHARSETS_ISO */
++
++#ifdef _MB_EXTENDED_CHARSETS_WINDOWS
++int
++_DEFUN (__cp_mbtowc, (r, pwc, s, n, charset, state),
++        struct _reent *r       _AND
++        wchar_t       *pwc     _AND 
++        const char    *s       _AND        
++        size_t         n       _AND
++	const char    *charset _AND
++        mbstate_t      *state)
++{
++  wchar_t dummy;
++  unsigned char *t = (unsigned char *)s;
++
++  if (pwc == NULL)
++    pwc = &dummy;
++
++  if (s == NULL)
++    return 0;
++
++  if (n == 0)
++    return -2;
++
++  if (*t >= 0x80)
+     {
+-      int char1;
+-      if (s == NULL)
+-        return 0;  /* not state-dependent */
+-      char1 = *t;
+-      if (_iseucjp (char1))
+-        {
+-          int char2 = t[1];     
+-          if (n <= 1)
+-            return -1;
+-          if (_iseucjp (char2))
+-            {
+-              *pwc = (((wchar_t)*t) << 8) + (wchar_t)(*(t+1));
+-              return 2;
+-            }
+-          else
+-            return -1;
+-        }
++      int cp_idx = __cp_index (charset + 2);
++      if (cp_idx >= 0)
++	{
++	  *pwc = __cp_conv[cp_idx][*t - 0x80];
++	  if (*pwc == 0) /* Invalid character */
++	    {
++	      r->_errno = EILSEQ;
++	      return -1;
++	    }
++	  return 1;
++	}
+     }
+-  else if (!strcmp (r->_current_locale, "C-JIS"))
++
++  *pwc = (wchar_t)*t;
++  
++  if (*t == '\0')
++    return 0;
++
++  return 1;
++}
++#endif /* _MB_EXTENDED_CHARSETS_WINDOWS */
++
++int
++_DEFUN (__utf8_mbtowc, (r, pwc, s, n, charset, state),
++        struct _reent *r       _AND
++        wchar_t       *pwc     _AND 
++        const char    *s       _AND        
++        size_t         n       _AND
++	const char    *charset _AND
++        mbstate_t      *state)
++{
++  wchar_t dummy;
++  unsigned char *t = (unsigned char *)s;
++  int ch;
++  int i = 0;
++
++  if (pwc == NULL)
++    pwc = &dummy;
++
++  if (s == NULL)
++    return 0;
++
++  if (n == 0)
++    return -2;
++
++  if (state->__count == 0)
++    ch = t[i++];
++  else
++    ch = state->__value.__wchb[0];
++
++  if (ch == '\0')
+     {
+-      JIS_STATE curr_state;
+-      JIS_ACTION action;
+-      JIS_CHAR_TYPE ch;
+-      unsigned char *ptr;
+-      int i, curr_ch;
+- 
+-      if (s == NULL)
+-        {
+-          *state = 0;
+-          return 1;  /* state-dependent */
+-        }
+-
+-      curr_state = (*state == 0 ? ASCII : JIS);
+-      ptr = t;
+-
+-      for (i = 0; i < n; ++i)
+-        {
+-          curr_ch = t[i];
+-          switch (curr_ch)
+-            {
+-	    case ESC_CHAR:
+-              ch = ESCAPE;
+-              break;
+-	    case '$':
+-              ch = DOLLAR;
+-              break;
+-            case '@':
+-              ch = AT;
+-              break;
+-            case '(':
+-	      ch = BRACKET;
+-              break;
+-            case 'B':
+-              ch = B;
+-              break;
+-            case 'J':
+-              ch = J;
+-              break;
+-            case '\0':
+-              ch = NUL;
+-              break;
+-            default:
+-              if (_isjis (curr_ch))
+-                ch = JIS_CHAR;
+-              else
+-                ch = OTHER;
+-	    }
++      *pwc = 0;
++      state->__count = 0;
++      return 0; /* s points to the null character */
++    }
+ 
+-          action = JIS_action_table[curr_state][ch];
+-          curr_state = JIS_state_table[curr_state][ch];
+-        
+-          switch (action)
+-            {
+-            case NOOP:
+-              break;
+-            case EMPTY:
+-              *state = 0;
+-              *pwc = (wchar_t)0;
+-              return i;
+-            case COPY_A:
+-	      *state = 0;
+-              *pwc = (wchar_t)*ptr;
+-              return (i + 1);
+-            case COPY_J:
+-              *state = 0;
+-              *pwc = (((wchar_t)*ptr) << 8) + (wchar_t)(*(ptr+1));
+-              return (i + 1);
+-            case COPY_J2:
+-              *state = 1;
+-              *pwc = (((wchar_t)*ptr) << 8) + (wchar_t)(*(ptr+1));
+-              return (ptr - t) + 2;
+-            case MAKE_A:
+-            case MAKE_J:
+-              ptr = (char *)(t + i + 1);
+-              break;
+-            case ERROR:
+-            default:
+-              return -1;
+-            }
+-
+-        }
+-
+-      return -1;  /* n < bytes needed */
++  if (ch <= 0x7f)
++    {
++      /* single-byte sequence */
++      state->__count = 0;
++      *pwc = ch;
++      return 1;
++    }
++  if (ch >= 0xc0 && ch <= 0xdf)
++    {
++      /* two-byte sequence */
++      state->__value.__wchb[0] = ch;
++      if (state->__count == 0)
++	state->__count = 1;
++      else if (n < (size_t)-1)
++	++n;
++      if (n < 2)
++	return -2;
++      ch = t[i++];
++      if (ch < 0x80 || ch > 0xbf)
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      if (state->__value.__wchb[0] < 0xc2)
++	{
++	  /* overlong UTF-8 sequence */
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      state->__count = 0;
++      *pwc = (wchar_t)((state->__value.__wchb[0] & 0x1f) << 6)
++	|    (wchar_t)(ch & 0x3f);
++      return i;
++    }
++  if (ch >= 0xe0 && ch <= 0xef)
++    {
++      /* three-byte sequence */
++      wchar_t tmp;
++      state->__value.__wchb[0] = ch;
++      if (state->__count == 0)
++	state->__count = 1;
++      else if (n < (size_t)-1)
++	++n;
++      if (n < 2)
++	return -2;
++      ch = (state->__count == 1) ? t[i++] : state->__value.__wchb[1];
++      if (state->__value.__wchb[0] == 0xe0 && ch < 0xa0)
++	{
++	  /* overlong UTF-8 sequence */
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      if (ch < 0x80 || ch > 0xbf)
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      state->__value.__wchb[1] = ch;
++      if (state->__count == 1)
++	state->__count = 2;
++      else if (n < (size_t)-1)
++	++n;
++      if (n < 3)
++	return -2;
++      ch = t[i++];
++      if (ch < 0x80 || ch > 0xbf)
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      state->__count = 0;
++      tmp = (wchar_t)((state->__value.__wchb[0] & 0x0f) << 12)
++	|    (wchar_t)((state->__value.__wchb[1] & 0x3f) << 6)
++	|     (wchar_t)(ch & 0x3f);
++      *pwc = tmp;
++      return i;
++    }
++  if (ch >= 0xf0 && ch <= 0xf4)
++    {
++      /* four-byte sequence */
++      wint_t tmp;
++      state->__value.__wchb[0] = ch;
++      if (state->__count == 0)
++	state->__count = 1;
++      else if (n < (size_t)-1)
++	++n;
++      if (n < 2)
++	return -2;
++      ch = (state->__count == 1) ? t[i++] : state->__value.__wchb[1];
++      if ((state->__value.__wchb[0] == 0xf0 && ch < 0x90)
++	  || (state->__value.__wchb[0] == 0xf4 && ch >= 0x90))
++	{
++	  /* overlong UTF-8 sequence or result is > 0x10ffff */
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      if (ch < 0x80 || ch > 0xbf)
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      state->__value.__wchb[1] = ch;
++      if (state->__count == 1)
++	state->__count = 2;
++      else if (n < (size_t)-1)
++	++n;
++      if (n < 3)
++	return -2;
++      ch = (state->__count == 2) ? t[i++] : state->__value.__wchb[2];
++      if (ch < 0x80 || ch > 0xbf)
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      state->__value.__wchb[2] = ch;
++      if (state->__count == 2)
++	state->__count = 3;
++      else if (n < (size_t)-1)
++	++n;
++      if (state->__count == 3 && sizeof(wchar_t) == 2)
++	{
++	  /* On systems which have wchar_t being UTF-16 values, the value
++	     doesn't fit into a single wchar_t in this case.  So what we
++	     do here is to store the state with a special value of __count
++	     and return the first half of a surrogate pair.  The first
++	     three bytes of a UTF-8 sequence are enough to generate the
++	     first half of a UTF-16 surrogate pair.  As return value we
++	     choose to return the number of bytes actually read up to
++	     here.
++	     The second half of the surrogate pair is returned in case we
++	     recognize the special __count value of four, and the next
++	     byte is actually a valid value.  See below. */
++	  tmp = (wint_t)((state->__value.__wchb[0] & 0x07) << 18)
++	    |   (wint_t)((state->__value.__wchb[1] & 0x3f) << 12)
++	    |   (wint_t)((state->__value.__wchb[2] & 0x3f) << 6);
++	  state->__count = 4;
++	  *pwc = 0xd800 | ((tmp - 0x10000) >> 10);
++	  return i;
++	}
++      if (n < 4)
++	return -2;
++      ch = t[i++];
++      if (ch < 0x80 || ch > 0xbf)
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++      tmp = (wint_t)((state->__value.__wchb[0] & 0x07) << 18)
++	|   (wint_t)((state->__value.__wchb[1] & 0x3f) << 12)
++	|   (wint_t)((state->__value.__wchb[2] & 0x3f) << 6)
++	|   (wint_t)(ch & 0x3f);
++      if (state->__count == 4 && sizeof(wchar_t) == 2)
++	/* Create the second half of the surrogate pair for systems with
++	   wchar_t == UTF-16 . */
++	*pwc = 0xdc00 | (tmp & 0x3ff);
++      else
++	*pwc = tmp;
++      state->__count = 0;
++      return i;
+     }
+-#endif /* MB_CAPABLE */               
+ 
+-  /* otherwise this must be the "C" locale or unknown locale */
++  r->_errno = EILSEQ;
++  return -1;
++}
++
++/* Cygwin defines its own doublebyte charset conversion functions 
++   because the underlying OS requires wchar_t == UTF-16. */
++#if !defined(__CYGWIN__) && !defined(__MSYS__)
++int
++_DEFUN (__sjis_mbtowc, (r, pwc, s, n, charset, state),
++        struct _reent *r       _AND
++        wchar_t       *pwc     _AND 
++        const char    *s       _AND        
++        size_t         n       _AND
++	const char    *charset _AND
++        mbstate_t      *state)
++{
++  wchar_t dummy;
++  unsigned char *t = (unsigned char *)s;
++  int ch;
++  int i = 0;
++
++  if (pwc == NULL)
++    pwc = &dummy;
++
+   if (s == NULL)
+     return 0;  /* not state-dependent */
+ 
++  if (n == 0)
++    return -2;
++
++  ch = t[i++];
++  if (state->__count == 0)
++    {
++      if (_issjis1 (ch))
++	{
++	  state->__value.__wchb[0] = ch;
++	  state->__count = 1;
++	  if (n <= 1)
++	    return -2;
++	  ch = t[i++];
++	}
++    }
++  if (state->__count == 1)
++    {
++      if (_issjis2 (ch))
++	{
++	  *pwc = (((wchar_t)state->__value.__wchb[0]) << 8) + (wchar_t)ch;
++	  state->__count = 0;
++	  return i;
++	}
++      else  
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++    }
++
++  *pwc = (wchar_t)*t;
++  
++  if (*t == '\0')
++    return 0;
++
++  return 1;
++}
++
++int
++_DEFUN (__eucjp_mbtowc, (r, pwc, s, n, charset, state),
++        struct _reent *r       _AND
++        wchar_t       *pwc     _AND 
++        const char    *s       _AND        
++        size_t         n       _AND
++	const char    *charset _AND
++        mbstate_t      *state)
++{
++  wchar_t dummy;
++  unsigned char *t = (unsigned char *)s;
++  int ch;
++  int i = 0;
++
++  if (pwc == NULL)
++    pwc = &dummy;
++
++  if (s == NULL)
++    return 0;
++
++  if (n == 0)
++    return -2;
++
++  ch = t[i++];
++  if (state->__count == 0)
++    {
++      if (_iseucjp1 (ch))
++	{
++	  state->__value.__wchb[0] = ch;
++	  state->__count = 1;
++	  if (n <= 1)
++	    return -2;
++	  ch = t[i++];
++	}
++    }
++  if (state->__count == 1)
++    {
++      if (_iseucjp2 (ch))
++	{
++	  if (state->__value.__wchb[0] == 0x8f)
++	    {
++	      state->__value.__wchb[1] = ch;
++	      state->__count = 2;
++	      if (n <= i)
++		return -2;
++	      ch = t[i++];
++	    }
++	  else
++	    {
++	      *pwc = (((wchar_t)state->__value.__wchb[0]) << 8) + (wchar_t)ch;
++	      state->__count = 0;
++	      return i;
++	    }
++	}
++      else
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++    }
++  if (state->__count == 2)
++    {
++      if (_iseucjp2 (ch))
++	{
++	  *pwc = (((wchar_t)state->__value.__wchb[1]) << 8)
++		 + (wchar_t)(ch & 0x7f);
++	  state->__count = 0;
++	  return i;
++	}
++      else
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++    }
++
+   *pwc = (wchar_t)*t;
+   
+   if (*t == '\0')
+@@ -206,3 +540,107 @@ _DEFUN (_mbtowc_r, (r, pwc, s, n, state),
+   return 1;
+ }
+ 
++int
++_DEFUN (__jis_mbtowc, (r, pwc, s, n, charset, state),
++        struct _reent *r       _AND
++        wchar_t       *pwc     _AND 
++        const char    *s       _AND        
++        size_t         n       _AND
++	const char    *charset _AND
++        mbstate_t      *state)
++{
++  wchar_t dummy;
++  unsigned char *t = (unsigned char *)s;
++  JIS_STATE curr_state;
++  JIS_ACTION action;
++  JIS_CHAR_TYPE ch;
++  unsigned char *ptr;
++  unsigned int i;
++  int curr_ch;
++
++  if (pwc == NULL)
++    pwc = &dummy;
++
++  if (s == NULL)
++    {
++      state->__state = ASCII;
++      return 1;  /* state-dependent */
++    }
++
++  if (n == 0)
++    return -2;
++
++  curr_state = state->__state;
++  ptr = t;
++
++  for (i = 0; i < n; ++i)
++    {
++      curr_ch = t[i];
++      switch (curr_ch)
++	{
++	case ESC_CHAR:
++	  ch = ESCAPE;
++	  break;
++	case '$':
++	  ch = DOLLAR;
++	  break;
++	case '@':
++	  ch = AT;
++	  break;
++	case '(':
++	  ch = BRACKET;
++	  break;
++	case 'B':
++	  ch = B;
++	  break;
++	case 'J':
++	  ch = J;
++	  break;
++	case '\0':
++	  ch = NUL;
++	  break;
++	default:
++	  if (_isjis (curr_ch))
++	    ch = JIS_CHAR;
++	  else
++	    ch = OTHER;
++	}
++
++      action = JIS_action_table[curr_state][ch];
++      curr_state = JIS_state_table[curr_state][ch];
++    
++      switch (action)
++	{
++	case NOOP:
++	  break;
++	case EMPTY:
++	  state->__state = ASCII;
++	  *pwc = (wchar_t)0;
++	  return 0;
++	case COPY_A:
++	  state->__state = ASCII;
++	  *pwc = (wchar_t)*ptr;
++	  return (i + 1);
++	case COPY_J1:
++	  state->__value.__wchb[0] = t[i];
++	  break;
++	case COPY_J2:
++	  state->__state = JIS;
++	  *pwc = (((wchar_t)state->__value.__wchb[0]) << 8) + (wchar_t)(t[i]);
++	  return (i + 1);
++	case MAKE_A:
++	  ptr = (unsigned char *)(t + i + 1);
++	  break;
++	case ERROR:
++	default:
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++
++    }
++
++  state->__state = curr_state;
++  return -2;  /* n < bytes needed */
++}
++#endif /* !__CYGWIN__*/
++#endif /* _MB_CAPABLE */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcrtomb.c b/msys/rt/src/newlib/libc/stdlib/wcrtomb.c
+new file mode 100644
+index 0000000..60e0d89
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcrtomb.c
+@@ -0,0 +1,78 @@
++#include <reent.h>
++#include <newlib.h>
++#include <wchar.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <errno.h>
++#include "local.h"
++
++size_t
++_DEFUN (_wcrtomb_r, (ptr, s, wc, ps),
++	struct _reent *ptr _AND
++	char *s _AND
++	wchar_t wc _AND
++	mbstate_t *ps)
++{
++  int retval = 0;
++  char buf[10];
++
++#ifdef _MB_CAPABLE
++  if (ps == NULL)
++    {
++      _REENT_CHECK_MISC(ptr);
++      ps = &(_REENT_WCRTOMB_STATE(ptr));
++    }
++#endif
++
++  if (s == NULL)
++    retval = __wctomb (ptr, buf, L'\0', __locale_charset (), ps);
++  else
++    retval = __wctomb (ptr, s, wc, __locale_charset (), ps);
++
++  if (retval == -1)
++    {
++      ps->__count = 0;
++      ptr->_errno = EILSEQ;
++      return (size_t)(-1);
++    }
++  else
++    return (size_t)retval;
++}
++
++#ifndef _REENT_ONLY
++size_t
++_DEFUN (wcrtomb, (s, wc, ps),
++	char *s _AND
++	wchar_t wc _AND
++	mbstate_t *ps)
++{
++#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++  return _wcrtomb_r (_REENT, s, wc, ps);
++#else
++  int retval = 0;
++  char buf[10];
++
++#ifdef _MB_CAPABLE
++  if (ps == NULL)
++    {
++      _REENT_CHECK_MISC(_REENT);
++      ps = &(_REENT_WCRTOMB_STATE(_REENT));
++    }
++#endif
++
++  if (s == NULL)
++    retval = __wctomb (_REENT, buf, L'\0', __locale_charset (), ps);
++  else
++    retval = __wctomb (_REENT, s, wc, __locale_charset (), ps);
++
++  if (retval == -1)
++    {
++      ps->__count = 0;
++      _REENT->_errno = EILSEQ;
++      return (size_t)(-1);
++    }
++  else
++    return (size_t)retval;
++#endif /* not PREFER_SIZE_OVER_SPEED */
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcsnrtombs.c b/msys/rt/src/newlib/libc/stdlib/wcsnrtombs.c
+new file mode 100644
+index 0000000..5f885a4
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcsnrtombs.c
+@@ -0,0 +1,185 @@
++/*
++FUNCTION
++<<wcsrtombs>>, <<wcsnrtombs>>---convert a wide-character string to a character string
++
++INDEX
++	wcsrtombs
++INDEX
++	_wcsrtombs_r
++INDEX
++	wcsnrtombs
++INDEX
++	_wcsnrtombs_r
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	size_t wcsrtombs(char *<[dst]>, const wchar_t **<[src]>, size_t <[len]>,
++			 mbstate_t *<[ps]>);
++
++	#include <wchar.h>
++	size_t _wcsrtombs_r(struct _reent *<[ptr]>, char *<[dst]>,
++			    const wchar_t **<[src]>, size_t <[len]>,
++			    mbstate_t *<[ps]>);
++
++	#include <wchar.h>
++	size_t wcsnrtombs(char *<[dst]>, const wchar_t **<[src]>,
++			  size_t <[nwc]>, size_t <[len]>, mbstate_t *<[ps]>);
++
++	#include <wchar.h>
++	size_t _wcsnrtombs_r(struct _reent *<[ptr]>, char *<[dst]>,
++			     const wchar_t **<[src]>, size_t <[nwc]>,
++			     size_t <[len]>, mbstate_t *<[ps]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	size_t wcsrtombs(<[dst]>, <[src]>, <[len]>, <[ps]>)
++	char *<[dst]>;
++	const wchar_t **<[src]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++	#include <wchar.h>
++	size_t _wcsrtombs_r(<[ptr]>, <[dst]>, <[src]>, <[len]>, <[ps]>)
++	struct _rent *<[ptr]>;
++	char *<[dst]>;
++	const wchar_t **<[src]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++	#include <wchar.h>
++	size_t wcsnrtombs(<[dst]>, <[src]>, <[nwc]>, <[len]>, <[ps]>)
++	char *<[dst]>;
++	const wchar_t **<[src]>;
++	size_t <[nwc]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++	#include <wchar.h>
++	size_t _wcsnrtombs_r(<[ptr]>, <[dst]>, <[src]>, <[nwc]>, <[len]>, <[ps]>)
++	struct _rent *<[ptr]>;
++	char *<[dst]>;
++	const wchar_t **<[src]>;
++	size_t <[nwc]>;
++	size_t <[len]>;
++	mbstate_t *<[ps]>;
++
++DESCRIPTION
++The <<wcsrtombs>> function converts a string of wide characters indirectly
++pointed to by <[src]> to a corresponding multibyte character string stored in
++the array pointed to by <[dst}>.  No more than <[len]> bytes are written to
++<[dst}>.
++
++If <[dst}> is NULL, no characters are stored.
++
++If <[dst}> is not NULL, the pointer pointed to by <[src]> is updated to point
++to the character after the one that conversion stopped at.  If conversion
++stops because a null character is encountered, *<[src]> is set to NULL.
++
++The mbstate_t argument, <[ps]>, is used to keep track of the shift state.  If
++it is NULL, <<wcsrtombs>> uses an internal, static mbstate_t object, which
++is initialized to the initial conversion state at program startup.
++
++The <<wcsnrtombs>> function behaves identically to <<wcsrtombs>>, except that
++conversion stops after reading at most <[nwc]> characters from the buffer
++pointed to by <[src]>.
++
++RETURNS
++The <<wcsrtombs>> and <<wcsnrtombs>> functions return the number of bytes
++stored in the array pointed to by <[dst]> (not including any terminating
++null), if successful, otherwise it returns (size_t)-1.
++
++PORTABILITY
++<<wcsrtombs>> is defined by C99 standard.
++<<wcsnrtombs>> is defined by the POSIX.1-2008 standard.
++*/
++
++#include <reent.h>
++#include <newlib.h>
++#include <wchar.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <errno.h>
++#include "local.h"
++
++size_t
++_DEFUN (_wcsnrtombs_r, (r, dst, src, nwc, len, ps),
++	struct _reent *r _AND
++	char *dst _AND
++	const wchar_t **src _AND
++	size_t nwc _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  char *ptr = dst;
++  char buff[10];
++  wchar_t *pwcs;
++  size_t n;
++  int i;
++
++#ifdef _MB_CAPABLE
++  if (ps == NULL)
++    {
++      _REENT_CHECK_MISC(r);
++      ps = &(_REENT_WCSRTOMBS_STATE(r));
++    }
++#endif
++
++  /* If no dst pointer, treat len as maximum possible value. */
++  if (dst == NULL)
++    len = (size_t)-1;
++
++  n = 0;
++  pwcs = (wchar_t *)(*src);
++
++  while (n < len && nwc-- > 0)
++    {
++      int count = ps->__count;
++      wint_t wch = ps->__value.__wch;
++      int bytes = __wctomb (r, buff, *pwcs, __locale_charset (), ps);
++      if (bytes == -1)
++	{
++	  r->_errno = EILSEQ;
++	  ps->__count = 0;
++	  return (size_t)-1;
++	}
++      if (n + bytes <= len)
++	{
++          n += bytes;
++	  if (dst)
++	    {
++	      for (i = 0; i < bytes; ++i)
++	        *ptr++ = buff[i];
++	      ++(*src);
++	    }
++	  if (*pwcs++ == 0x00)
++	    {
++	      if (dst)
++	        *src = NULL;
++	      ps->__count = 0;
++	      return n - 1;
++	    }
++	}
++      else
++	{
++	  /* not enough room, we must back up state to before __wctomb call */
++	  ps->__count = count;
++	  ps->__value.__wch = wch;
++          len = 0;
++	}
++    }
++
++  return n;
++} 
++
++#ifndef _REENT_ONLY
++size_t
++_DEFUN (wcsnrtombs, (dst, src, nwc, len, ps),
++	char *dst _AND
++	const wchar_t **src _AND
++	size_t nwc _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  return _wcsnrtombs_r (_REENT, dst, src, nwc, len, ps);
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcsrtombs.c b/msys/rt/src/newlib/libc/stdlib/wcsrtombs.c
+new file mode 100644
+index 0000000..ea6bd9d
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcsrtombs.c
+@@ -0,0 +1,26 @@
++#include <reent.h>
++#include <newlib.h>
++#include <wchar.h>
++
++size_t
++_DEFUN (_wcsrtombs_r, (r, dst, src, len, ps),
++	struct _reent *r _AND
++	char *dst _AND
++	const wchar_t **src _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  return _wcsnrtombs_r (r, dst, src, (size_t) -1, len, ps);
++} 
++
++#ifndef _REENT_ONLY
++size_t
++_DEFUN (wcsrtombs, (dst, src, len, ps),
++	char *dst _AND
++	const wchar_t **src _AND
++	size_t len _AND
++	mbstate_t *ps)
++{
++  return _wcsnrtombs_r (_REENT, dst, src, (size_t) -1, len, ps);
++}
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstod.c b/msys/rt/src/newlib/libc/stdlib/wcstod.c
+new file mode 100644
+index 0000000..d80454c
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstod.c
+@@ -0,0 +1,230 @@
++/*
++FUNCTION
++        <<wcstod>>, <<wcstof>>---wide char string to double or float
++
++INDEX
++	wcstod
++INDEX
++	_wcstod_r
++INDEX
++	wcstof
++INDEX
++	_wcstof_r
++
++ANSI_SYNOPSIS
++        #include <stdlib.h>
++        double wcstod(const wchar_t *<[str]>, wchar_t **<[tail]>);
++        float wcstof(const wchar_t *<[str]>, wchar_t **<[tail]>);
++
++        double _wcstod_r(void *<[reent]>,
++                         const wchar_t *<[str]>, wchar_t **<[tail]>);
++        float _wcstof_r(void *<[reent]>,
++                         const wchar_t *<[str]>, wchar_t **<[tail]>);
++
++TRAD_SYNOPSIS
++        #include <stdlib.h>
++        double wcstod(<[str]>,<[tail]>)
++        wchar_t *<[str]>;
++        wchar_t **<[tail]>;
++
++        float wcstof(<[str]>,<[tail]>)
++        wchar_t *<[str]>;
++        wchar_t **<[tail]>;
++
++        double _wcstod_r(<[reent]>,<[str]>,<[tail]>)
++	wchar_t *<[reent]>;
++        wchar_t *<[str]>;
++        wchar_t **<[tail]>;
++
++        float _wcstof_r(<[reent]>,<[str]>,<[tail]>)
++	wchar_t *<[reent]>;
++        wchar_t *<[str]>;
++        wchar_t **<[tail]>;
++
++DESCRIPTION
++	The function <<wcstod>> parses the wide character string <[str]>,
++	producing a substring which can be converted to a double
++	value.  The substring converted is the longest initial
++	subsequence of <[str]>, beginning with the first
++	non-whitespace character, that has one of these formats:
++	.[+|-]<[digits]>[.[<[digits]>]][(e|E)[+|-]<[digits]>]
++	.[+|-].<[digits]>[(e|E)[+|-]<[digits]>]
++	.[+|-](i|I)(n|N)(f|F)[(i|I)(n|N)(i|I)(t|T)(y|Y)]
++	.[+|-](n|N)(a|A)(n|N)[<(>[<[hexdigits]>]<)>]
++	.[+|-]0(x|X)<[hexdigits]>[.[<[hexdigits]>]][(p|P)[+|-]<[digits]>]
++	.[+|-]0(x|X).<[hexdigits]>[(p|P)[+|-]<[digits]>]
++	The substring contains no characters if <[str]> is empty, consists
++	entirely of whitespace, or if the first non-whitespace
++	character is something other than <<+>>, <<->>, <<.>>, or a
++	digit, and cannot be parsed as infinity or NaN. If the platform
++	does not support NaN, then NaN is treated as an empty substring.
++	If the substring is empty, no conversion is done, and
++	the value of <[str]> is stored in <<*<[tail]>>>.  Otherwise,
++	the substring is converted, and a pointer to the final string
++	(which will contain at least the terminating null character of
++	<[str]>) is stored in <<*<[tail]>>>.  If you want no
++	assignment to <<*<[tail]>>>, pass a null pointer as <[tail]>.
++	<<wcstof>> is identical to <<wcstod>> except for its return type.
++
++	This implementation returns the nearest machine number to the
++	input decimal string.  Ties are broken by using the IEEE
++	round-even rule.  However, <<wcstof>> is currently subject to
++	double rounding errors.
++
++	The alternate functions <<_wcstod_r>> and <<_wcstof_r>> are 
++	reentrant versions of <<wcstod>> and <<wcstof>>, respectively.
++	The extra argument <[reent]> is a pointer to a reentrancy structure.
++
++RETURNS
++	Return the converted substring value, if any.  If
++	no conversion could be performed, 0 is returned.  If the
++	correct value is out of the range of representable values,
++	plus or minus <<HUGE_VAL>> is returned, and <<ERANGE>> is
++	stored in errno. If the correct value would cause underflow, 0
++	is returned and <<ERANGE>> is stored in errno.
++
++Supporting OS subroutines required: <<close>>, <<fstat>>, <<isatty>>,
++<<lseek>>, <<read>>, <<sbrk>>, <<write>>.
++*/
++
++/*-
++ * Copyright (c) 2002 Tim J. Robbins
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <_ansi.h>
++#include <errno.h>
++#include <stdlib.h>
++#include <string.h>
++#include <wchar.h>
++#include <wctype.h>
++#include <locale.h>
++#include <math.h>
++
++double
++_DEFUN (_wcstod_r, (ptr, nptr, endptr),
++	struct _reent *ptr _AND
++	_CONST wchar_t *nptr _AND
++	wchar_t **endptr)
++{
++        static const mbstate_t initial;
++        mbstate_t mbs;
++        double val;
++        char *buf, *end;
++        const wchar_t *wcp;
++        size_t len;
++
++        while (iswspace(*nptr))
++                nptr++;
++
++        /*
++         * Convert the supplied numeric wide char. string to multibyte.
++         *
++         * We could attempt to find the end of the numeric portion of the
++         * wide char. string to avoid converting unneeded characters but
++         * choose not to bother; optimising the uncommon case where
++         * the input string contains a lot of text after the number
++         * duplicates a lot of strtod()'s functionality and slows down the
++         * most common cases.
++         */
++        wcp = nptr;
++        mbs = initial;
++        if ((len = _wcsrtombs_r(ptr, NULL, &wcp, 0, &mbs)) == (size_t)-1) {
++                if (endptr != NULL)
++                        *endptr = (wchar_t *)nptr;
++                return (0.0);
++        }
++        if ((buf = _malloc_r(ptr, len + 1)) == NULL)
++                return (0.0);
++        mbs = initial;
++        _wcsrtombs_r(ptr, buf, &wcp, len + 1, &mbs);
++
++        /* Let strtod() do most of the work for us. */
++        val = _strtod_r(ptr, buf, &end);
++
++        /*
++         * We only know where the number ended in the _multibyte_
++         * representation of the string. If the caller wants to know
++         * where it ended, count multibyte characters to find the
++         * corresponding position in the wide char string.
++         */
++        if (endptr != NULL) {
++		/* The only valid multibyte char in a float converted by
++		   strtod/wcstod is the radix char.  What we do here is,
++		   figure out if the radix char was in the valid leading
++		   float sequence in the incoming string.  If so, the
++		   multibyte float string is strlen(radix char) - 1 bytes
++		   longer than the incoming wide char string has characters.
++		   To fix endptr, reposition end as if the radix char was
++		   just one byte long.  The resulting difference (end - buf)
++		   is then equivalent to the number of valid wide characters
++		   in the input string. */
++		len = strlen (_localeconv_r (ptr)->decimal_point);
++		if (len > 1) {
++			char *d = strstr (buf,
++					  _localeconv_r (ptr)->decimal_point);
++			if (d && d < end)
++				end -= len - 1;
++		}
++                *endptr = (wchar_t *)nptr + (end - buf);
++	}
++
++        _free_r(ptr, buf);
++
++        return (val);
++}
++
++float
++_DEFUN (_wcstof_r, (ptr, nptr, endptr),
++	struct _reent *ptr _AND
++	_CONST wchar_t *nptr _AND
++	wchar_t **endptr)
++{
++  double retval = _wcstod_r (ptr, nptr, endptr);
++  if (isnan (retval))
++    return nanf (NULL);
++  return (float)retval;
++}
++
++#ifndef _REENT_ONLY
++
++double
++_DEFUN (wcstod, (nptr, endptr),
++	_CONST wchar_t *nptr _AND wchar_t **endptr)
++{
++  return _wcstod_r (_REENT, nptr, endptr);
++}
++
++float
++_DEFUN (wcstof, (nptr, endptr),
++	_CONST wchar_t *nptr _AND
++	wchar_t **endptr)
++{
++  double retval = _wcstod_r (_REENT, nptr, endptr);
++  if (isnan (retval))
++    return nanf (NULL);
++  return (float)retval;
++}
++
++#endif
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstol.c b/msys/rt/src/newlib/libc/stdlib/wcstol.c
+new file mode 100644
+index 0000000..e23254d
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstol.c
+@@ -0,0 +1,226 @@
++/*
++FUNCTION
++   <<wcstol>>---wide string to long
++
++INDEX
++	wcstol
++INDEX
++	_wcstol_r
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++        long wcstol(const wchar_t *<[s]>, wchar_t **<[ptr]>,int <[base]>);
++
++        long _wcstol_r(void *<[reent]>, 
++                       const wchar_t *<[s]>, wchar_t **<[ptr]>,int <[base]>);
++
++TRAD_SYNOPSIS
++	#include <stdlib.h>
++	long wcstol (<[s]>, <[ptr]>, <[base]>)
++        wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++	long _wcstol_r (<[reent]>, <[s]>, <[ptr]>, <[base]>)
++	struct _reent *<[reent]>;
++        wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++DESCRIPTION
++The function <<wcstol>> converts the wide string <<*<[s]>>> to
++a <<long>>. First, it breaks down the string into three parts:
++leading whitespace, which is ignored; a subject string consisting
++of characters resembling an integer in the radix specified by <[base]>;
++and a trailing portion consisting of zero or more unparseable characters,
++and always including the terminating null character. Then, it attempts
++to convert the subject string into a <<long>> and returns the
++result.
++
++If the value of <[base]> is 0, the subject string is expected to look
++like a normal C integer constant: an optional sign, a possible `<<0x>>'
++indicating a hexadecimal base, and a number. If <[base]> is between
++2 and 36, the expected form of the subject is a sequence of letters
++and digits representing an integer in the radix specified by <[base]>,
++with an optional plus or minus sign. The letters <<a>>--<<z>> (or,
++equivalently, <<A>>--<<Z>>) are used to signify values from 10 to 35;
++only letters whose ascribed values are less than <[base]> are
++permitted. If <[base]> is 16, a leading <<0x>> is permitted.
++
++The subject sequence is the longest initial sequence of the input
++string that has the expected form, starting with the first
++non-whitespace character.  If the string is empty or consists entirely
++of whitespace, or if the first non-whitespace character is not a
++permissible letter or digit, the subject string is empty.
++
++If the subject string is acceptable, and the value of <[base]> is zero,
++<<wcstol>> attempts to determine the radix from the input string. A
++string with a leading <<0x>> is treated as a hexadecimal value; a string with
++a leading 0 and no <<x>> is treated as octal; all other strings are
++treated as decimal. If <[base]> is between 2 and 36, it is used as the
++conversion radix, as described above. If the subject string begins with
++a minus sign, the value is negated. Finally, a pointer to the first
++character past the converted subject string is stored in <[ptr]>, if
++<[ptr]> is not <<NULL>>.
++
++If the subject string is empty (or not in acceptable form), no conversion
++is performed and the value of <[s]> is stored in <[ptr]> (if <[ptr]> is
++not <<NULL>>).
++
++The alternate function <<_wcstol_r>> is a reentrant version.  The
++extra argument <[reent]> is a pointer to a reentrancy structure.
++
++RETURNS
++<<wcstol>> returns the converted value, if any. If no conversion was
++made, 0 is returned.
++
++<<wcstol>> returns <<LONG_MAX>> or <<LONG_MIN>> if the magnitude of
++the converted value is too large, and sets <<errno>> to <<ERANGE>>.
++
++PORTABILITY
++<<wcstol>> is ANSI.
++
++No supporting OS subroutines are required.
++*/
++
++/*-
++ * Copyright (c) 1990 The Regents of the University of California.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++
++#include <_ansi.h>
++#include <limits.h>
++#include <wctype.h>
++#include <errno.h>
++#include <wchar.h>
++#include <reent.h>
++
++/*
++ * Convert a wide string to a long integer.
++ *
++ * Ignores `locale' stuff.  Assumes that the upper and lower case
++ * alphabets and digits are each contiguous.
++ */
++long
++_DEFUN (_wcstol_r, (rptr, nptr, endptr, base),
++	struct _reent *rptr _AND
++	_CONST wchar_t *nptr _AND
++	wchar_t **endptr _AND
++	int base)
++{
++	register const wchar_t *s = nptr;
++	register unsigned long acc;
++	register int c;
++	register unsigned long cutoff;
++	register int neg = 0, any, cutlim;
++
++	/*
++	 * Skip white space and pick up leading +/- sign if any.
++	 * If base is 0, allow 0x for hex and 0 for octal, else
++	 * assume decimal; if base is already 16, allow 0x.
++	 */
++	do {
++		c = *s++;
++	} while (iswspace(c));
++	if (c == L'-') {
++		neg = 1;
++		c = *s++;
++	} else if (c == L'+')
++		c = *s++;
++	if ((base == 0 || base == 16) &&
++	    c == L'0' && (*s == L'x' || *s == L'X')) {
++		c = s[1];
++		s += 2;
++		base = 16;
++	}
++	if (base == 0)
++		base = c == L'0' ? 8 : 10;
++
++	/*
++	 * Compute the cutoff value between legal numbers and illegal
++	 * numbers.  That is the largest legal value, divided by the
++	 * base.  An input number that is greater than this value, if
++	 * followed by a legal input character, is too big.  One that
++	 * is equal to this value may be valid or not; the limit
++	 * between valid and invalid numbers is then based on the last
++	 * digit.  For instance, if the range for longs is
++	 * [-2147483648..2147483647] and the input base is 10,
++	 * cutoff will be set to 214748364 and cutlim to either
++	 * 7 (neg==0) or 8 (neg==1), meaning that if we have accumulated
++	 * a value > 214748364, or equal but the next digit is > 7 (or 8),
++	 * the number is too big, and we will return a range error.
++	 *
++	 * Set any if any `digits' consumed; make it negative to indicate
++	 * overflow.
++	 */
++	cutoff = neg ? -(unsigned long)LONG_MIN : LONG_MAX;
++	cutlim = cutoff % (unsigned long)base;
++	cutoff /= (unsigned long)base;
++	for (acc = 0, any = 0;; c = *s++) {
++		if (iswdigit(c))
++			c -= L'0';
++		else if (iswalpha(c))
++			c -= iswupper(c) ? L'A' - 10 : L'a' - 10;
++		else
++			break;
++		if (c >= base)
++			break;
++               if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
++			any = -1;
++		else {
++			any = 1;
++			acc *= base;
++			acc += c;
++		}
++	}
++	if (any < 0) {
++		acc = neg ? LONG_MIN : LONG_MAX;
++		rptr->_errno = ERANGE;
++	} else if (neg)
++		acc = -acc;
++	if (endptr != 0)
++		*endptr = (wchar_t *) (any ? s - 1 : nptr);
++	return (acc);
++}
++
++#ifndef _REENT_ONLY
++
++long
++_DEFUN (wcstol, (s, ptr, base),
++	_CONST wchar_t *s _AND
++	wchar_t **ptr _AND
++	int base)
++{
++	return _wcstol_r (_REENT, s, ptr, base);
++}
++
++#endif
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstold.c b/msys/rt/src/newlib/libc/stdlib/wcstold.c
+new file mode 100644
+index 0000000..8b0ba24
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstold.c
+@@ -0,0 +1,42 @@
++/*
++(C) Copyright IBM Corp. 2009
++
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++* Redistributions of source code must retain the above copyright notice,
++this list of conditions and the following disclaimer.
++* Redistributions in binary form must reproduce the above copyright
++notice, this list of conditions and the following disclaimer in the
++documentation and/or other materials provided with the distribution.
++* Neither the name of IBM nor the names of its contributors may be
++used to endorse or promote products derived from this software without
++specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
++LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#include <stdlib.h>
++#include "local.h"
++
++/* On platforms where long double is as wide as double.  */
++#ifdef _LDBL_EQ_DBL
++long double
++wcstold (const wchar_t *nptr, wchar_t **endptr)
++{
++  return wcstod(nptr, endptr);
++}
++#endif /* _LDBL_EQ_DBL */
++
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstoll.c b/msys/rt/src/newlib/libc/stdlib/wcstoll.c
+new file mode 100644
+index 0000000..75eda9f
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstoll.c
+@@ -0,0 +1,138 @@
++/*
++FUNCTION
++   <<wcstoll>>---wide string to long long
++
++INDEX
++	wcstoll
++INDEX
++	_wcstoll_r
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++        long long wcstoll(const wchar_t *<[s]>, wchar_t **<[ptr]>,int <[base]>);
++
++        long long _wcstoll_r(void *<[reent]>, 
++                       const wchar_t *<[s]>, wchar_t **<[ptr]>,int <[base]>);
++
++TRAD_SYNOPSIS
++	#include <stdlib.h>
++	long long wcstoll (<[s]>, <[ptr]>, <[base]>)
++        const wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++	long long _wcstoll_r (<[reent]>, <[s]>, <[ptr]>, <[base]>)
++	wchar_t *<[reent]>;
++        const wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++DESCRIPTION
++The function <<wcstoll>> converts the wide string <<*<[s]>>> to
++a <<long long>>. First, it breaks down the string into three parts:
++leading whitespace, which is ignored; a subject string consisting
++of characters resembling an integer in the radix specified by <[base]>;
++and a trailing portion consisting of zero or more unparseable characters,
++and always including the terminating null character. Then, it attempts
++to convert the subject string into a <<long long>> and returns the
++result.
++
++If the value of <[base]> is 0, the subject string is expected to look
++like a normal C integer constant: an optional sign, a possible `<<0x>>'
++indicating a hexadecimal base, and a number. If <[base]> is between
++2 and 36, the expected form of the subject is a sequence of letters
++and digits representing an integer in the radix specified by <[base]>,
++with an optional plus or minus sign. The letters <<a>>--<<z>> (or,
++equivalently, <<A>>--<<Z>>) are used to signify values from 10 to 35;
++only letters whose ascribed values are less than <[base]> are
++permitted. If <[base]> is 16, a leading <<0x>> is permitted.
++
++The subject sequence is the longest initial sequence of the input
++string that has the expected form, starting with the first
++non-whitespace character.  If the string is empty or consists entirely
++of whitespace, or if the first non-whitespace character is not a
++permissible letter or digit, the subject string is empty.
++
++If the subject string is acceptable, and the value of <[base]> is zero,
++<<wcstoll>> attempts to determine the radix from the input string. A
++string with a leading <<0x>> is treated as a hexadecimal value; a string with
++a leading 0 and no <<x>> is treated as octal; all other strings are
++treated as decimal. If <[base]> is between 2 and 36, it is used as the
++conversion radix, as described above. If the subject string begins with
++a minus sign, the value is negated. Finally, a pointer to the first
++character past the converted subject string is stored in <[ptr]>, if
++<[ptr]> is not <<NULL>>.
++
++If the subject string is empty (or not in acceptable form), no conversion
++is performed and the value of <[s]> is stored in <[ptr]> (if <[ptr]> is
++not <<NULL>>).
++
++The alternate function <<_wcstoll_r>> is a reentrant version.  The
++extra argument <[reent]> is a pointer to a reentrancy structure.
++
++RETURNS
++<<wcstoll>> returns the converted value, if any. If no conversion was
++made, 0 is returned.
++
++<<wcstoll>> returns <<LONG_LONG_MAX>> or <<LONG_LONG_MIN>> if the magnitude of
++the converted value is too large, and sets <<errno>> to <<ERANGE>>.
++
++PORTABILITY
++<<wcstoll>> is ANSI.
++
++No supporting OS subroutines are required.
++*/
++
++/*-
++ * Copyright (c) 1990 The Regents of the University of California.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++
++#include <_ansi.h>
++#include <limits.h>
++#include <wctype.h>
++#include <errno.h>
++#include <wchar.h>
++#include <reent.h>
++
++#ifndef _REENT_ONLY
++
++long long
++_DEFUN (wcstoll, (s, ptr, base),
++	_CONST wchar_t *s _AND
++	wchar_t **ptr _AND
++	int base)
++{
++	return _wcstoll_r (_REENT, s, ptr, base);
++}
++
++#endif
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstoll_r.c b/msys/rt/src/newlib/libc/stdlib/wcstoll_r.c
+new file mode 100644
+index 0000000..d6baaca
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstoll_r.c
+@@ -0,0 +1,140 @@
++/*
++  This code is based on strtoul.c which has the following copyright.
++  It is used to convert a wide string into a signed long long.
++
++  long long _wcstoll_r (struct _reent *rptr, const wchar_t *s, 
++                        wchar_t **ptr, int base);
++*/
++
++/*-
++ * Copyright (c) 1990 The Regents of the University of California.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#ifdef __GNUC__
++
++#define _GNU_SOURCE
++#include <_ansi.h>
++#include <limits.h>
++#include <wctype.h>
++#include <errno.h>
++#include <wchar.h>
++#include <reent.h>
++
++/*
++ * Convert a wide string to a long long integer.
++ *
++ * Ignores `locale' stuff.  Assumes that the upper and lower case
++ * alphabets and digits are each contiguous.
++ */
++long long
++_DEFUN (_wcstoll_r, (rptr, nptr, endptr, base),
++	struct _reent *rptr _AND
++	_CONST wchar_t *nptr _AND
++	wchar_t **endptr _AND
++	int base)
++{
++	register const wchar_t *s = nptr;
++	register unsigned long long acc;
++	register int c;
++	register unsigned long long cutoff;
++	register int neg = 0, any, cutlim;
++
++	/*
++	 * Skip white space and pick up leading +/- sign if any.
++	 * If base is 0, allow 0x for hex and 0 for octal, else
++	 * assume decimal; if base is already 16, allow 0x.
++	 */
++	do {
++		c = *s++;
++	} while (iswspace(c));
++	if (c == L'-') {
++		neg = 1;
++		c = *s++;
++	} else if (c == L'+')
++		c = *s++;
++	if ((base == 0 || base == 16) &&
++	    c == L'0' && (*s == L'x' || *s == L'X')) {
++		c = s[1];
++		s += 2;
++		base = 16;
++	}
++	if (base == 0)
++		base = c == L'0' ? 8 : 10;
++
++	/*
++	 * Compute the cutoff value between legal numbers and illegal
++	 * numbers.  That is the largest legal value, divided by the
++	 * base.  An input number that is greater than this value, if
++	 * followed by a legal input character, is too big.  One that
++	 * is equal to this value may be valid or not; the limit
++	 * between valid and invalid numbers is then based on the last
++	 * digit.  For instance, if the range for longs is
++	 * [-2147483648..2147483647] and the input base is 10,
++	 * cutoff will be set to 214748364 and cutlim to either
++	 * 7 (neg==0) or 8 (neg==1), meaning that if we have accumulated
++	 * a value > 214748364, or equal but the next digit is > 7 (or 8),
++	 * the number is too big, and we will return a range error.
++	 *
++	 * Set any if any `digits' consumed; make it negative to indicate
++	 * overflow.
++	 */
++	cutoff = neg ? -(unsigned long long)LONG_LONG_MIN : LONG_LONG_MAX;
++	cutlim = cutoff % (unsigned long long)base;
++	cutoff /= (unsigned long long)base;
++	for (acc = 0, any = 0;; c = *s++) {
++		if (iswdigit(c))
++			c -= L'0';
++		else if (iswalpha(c))
++			c -= iswupper(c) ? L'A' - 10 : L'a' - 10;
++		else
++			break;
++		if (c >= base)
++			break;
++               if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
++			any = -1;
++		else {
++			any = 1;
++			acc *= base;
++			acc += c;
++		}
++	}
++	if (any < 0) {
++		acc = neg ? LONG_LONG_MIN : LONG_LONG_MAX;
++		rptr->_errno = ERANGE;
++	} else if (neg)
++		acc = -acc;
++	if (endptr != 0)
++		*endptr = (wchar_t *) (any ? s - 1 : nptr);
++	return (acc);
++}
++
++#endif /* __GNUC__ */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstombs.c b/msys/rt/src/newlib/libc/stdlib/wcstombs.c
+index ca99f2e..d0ef26e 100644
+--- a/msys/rt/src/newlib/libc/stdlib/wcstombs.c
++++ b/msys/rt/src/newlib/libc/stdlib/wcstombs.c
+@@ -7,22 +7,22 @@ INDEX
+ 
+ ANSI_SYNOPSIS
+ 	#include <stdlib.h>
+-	int wcstombs(const char *<[s]>, wchar_t *<[pwc]>, size_t <[n]>);
++	size_t wcstombs(char *<[s]>, const wchar_t *<[pwc]>, size_t <[n]>);
+ 
+ TRAD_SYNOPSIS
+ 	#include <stdlib.h>
+-	int wcstombs(<[s]>, <[pwc]>, <[n]>)
+-	const char *<[s]>;
+-	wchar_t *<[pwc]>;
++	size_t wcstombs(<[s]>, <[pwc]>, <[n]>)
++	char *<[s]>;
++	const wchar_t *<[pwc]>;
+ 	size_t <[n]>;
+ 
+ DESCRIPTION
+-When MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
++When _MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
+ implementation of <<wcstombs>>.  In this case,
+ all wide-characters are expected to represent single bytes and so
+ are converted simply by casting to char.
+ 
+-When MB_CAPABLE is defined, this routine calls <<_wcstombs_r>> to perform
++When _MB_CAPABLE is defined, this routine calls <<_wcstombs_r>> to perform
+ the conversion, passing a state variable to allow state dependent
+ decoding.  The result is based on the locale setting which may
+ be restricted to a defined set of locales.
+@@ -30,7 +30,7 @@ be restricted to a defined set of locales.
+ RETURNS
+ This implementation of <<wcstombs>> returns <<0>> if
+ <[s]> is <<NULL>> or is the empty string; 
+-it returns <<-1>> if MB_CAPABLE and one of the
++it returns <<-1>> if _MB_CAPABLE and one of the
+ wide-char characters does not represent a valid multi-byte character;
+ otherwise it returns the minimum of: <<n>> or the
+ number of bytes that are transferred to <<s>>, not including the
+@@ -50,7 +50,9 @@ effects vary with the locale.
+ 
+ #ifndef _REENT_ONLY
+ 
++#include <newlib.h>
+ #include <stdlib.h>
++#include <wchar.h>
+ 
+ size_t
+ _DEFUN (wcstombs, (s, pwcs, n),
+@@ -58,23 +60,24 @@ _DEFUN (wcstombs, (s, pwcs, n),
+         const wchar_t *pwcs _AND
+         size_t         n)
+ {
+-#ifdef MB_CAPABLE
+-        int state = 0;
+-
+-        return _wcstombs_r (_REENT, s, pwcs, n, &state);
+-#else /* not MB_CAPABLE */
+-        int count = 0;
+-
+-        if (n != 0) {
+-                do {
+-                        if ((*s++ = (char) *pwcs++) == 0)
+-                                break;
+-                        count++;
+-                } while (--n != 0);
+-        }
+-
+-        return count;
+-#endif /* not MB_CAPABLE */
++#ifdef _MB_CAPABLE
++  mbstate_t state;
++  state.__count = 0;
++  
++  return _wcstombs_r (_REENT, s, pwcs, n, &state);
++#else /* not _MB_CAPABLE */
++  int count = 0;
++  
++  if (n != 0) {
++    do {
++      if ((*s++ = (char) *pwcs++) == 0)
++	break;
++      count++;
++    } while (--n != 0);
++  }
++  
++  return count;
++#endif /* not _MB_CAPABLE */
+ }
+ 
+ #endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstombs_r.c b/msys/rt/src/newlib/libc/stdlib/wcstombs_r.c
+index 69c82d4..e74502f 100644
+--- a/msys/rt/src/newlib/libc/stdlib/wcstombs_r.c
++++ b/msys/rt/src/newlib/libc/stdlib/wcstombs_r.c
+@@ -1,4 +1,6 @@
+ #include <stdlib.h>
++#include <wchar.h>
++#include "local.h"
+ 
+ size_t
+ _DEFUN (_wcstombs_r, (reent, s, pwcs, n, state),
+@@ -6,27 +8,41 @@ _DEFUN (_wcstombs_r, (reent, s, pwcs, n, state),
+         char          *s    _AND
+         const wchar_t *pwcs _AND
+         size_t         n    _AND
+-        int           *state)
++        mbstate_t     *state)
+ {
+   char *ptr = s;
+   size_t max = n;
+   char buff[8];
+-  int i, num_to_copy;
++  int i, bytes, num_to_copy;
+ 
+-  while (n > 0)
++  if (s == NULL)
+     {
+-      int bytes = _wctomb_r (r, buff, *pwcs, state);
+-      if (bytes == -1)
+-        return -1;
+-      num_to_copy = (n > bytes ? bytes : (int)n);
+-      for (i = 0; i < num_to_copy; ++i)
+-        *ptr++ = buff[i];
++      size_t num_bytes = 0;
++      while (*pwcs != 0)
++	{
++	  bytes = __wctomb (r, buff, *pwcs++, __locale_charset (), state);
++	  if (bytes == -1)
++	    return -1;
++	  num_bytes += bytes;
++	}
++      return num_bytes;
++    }
++  else
++    {
++      while (n > 0)
++        {
++          bytes = __wctomb (r, buff, *pwcs, __locale_charset (), state);
++          if (bytes == -1)
++            return -1;
++          num_to_copy = (n > bytes ? bytes : (int)n);
++          for (i = 0; i < num_to_copy; ++i)
++            *ptr++ = buff[i];
+           
+-      if (*pwcs == 0x00)
+-        return ptr - s - (n >= bytes);
+-      ++pwcs;
+-      n -= num_to_copy;
++          if (*pwcs == 0x00)
++            return ptr - s - (n >= bytes);
++          ++pwcs;
++          n -= num_to_copy;
++        }
++      return max;
+     }
+-
+-  return max;
+ } 
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstoul.c b/msys/rt/src/newlib/libc/stdlib/wcstoul.c
+new file mode 100644
+index 0000000..44dfca3
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstoul.c
+@@ -0,0 +1,207 @@
++/*
++FUNCTION
++	<<wcstoul>>---wide string to unsigned long
++
++INDEX
++	wcstoul
++INDEX
++	_wcstoul_r
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++        unsigned long wcstoul(const wchar_t *<[s]>, wchar_t **<[ptr]>,
++                              int <[base]>);
++
++        unsigned long _wcstoul_r(void *<[reent]>, const wchar_t *<[s]>,
++                              wchar_t **<[ptr]>, int <[base]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++        unsigned long wcstoul(<[s]>, <[ptr]>, <[base]>)
++        wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++        unsigned long _wcstoul_r(<[reent]>, <[s]>, <[ptr]>, <[base]>)
++	wchar_t *<[reent]>;
++        wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++DESCRIPTION
++The function <<wcstoul>> converts the wide string <<*<[s]>>> to
++an <<unsigned long>>. First, it breaks down the string into three parts:
++leading whitespace, which is ignored; a subject string consisting
++of the digits meaningful in the radix specified by <[base]>
++(for example, <<0>> through <<7>> if the value of <[base]> is 8);
++and a trailing portion consisting of one or more unparseable characters,
++which always includes the terminating null character. Then, it attempts
++to convert the subject string into an unsigned long integer, and returns the
++result.
++
++If the value of <[base]> is zero, the subject string is expected to look
++like a normal C integer constant (save that no optional sign is permitted):
++a possible <<0x>> indicating hexadecimal radix, and a number.
++If <[base]> is between 2 and 36, the expected form of the subject is a
++sequence of digits (which may include letters, depending on the
++base) representing an integer in the radix specified by <[base]>.
++The letters <<a>>--<<z>> (or <<A>>--<<Z>>) are used as digits valued from
++10 to 35. If <[base]> is 16, a leading <<0x>> is permitted.
++
++The subject sequence is the longest initial sequence of the input
++string that has the expected form, starting with the first
++non-whitespace character.  If the string is empty or consists entirely
++of whitespace, or if the first non-whitespace character is not a
++permissible digit, the subject string is empty.
++
++If the subject string is acceptable, and the value of <[base]> is zero,
++<<wcstoul>> attempts to determine the radix from the input string. A
++string with a leading <<0x>> is treated as a hexadecimal value; a string with
++a leading <<0>> and no <<x>> is treated as octal; all other strings are
++treated as decimal. If <[base]> is between 2 and 36, it is used as the
++conversion radix, as described above. Finally, a pointer to the first
++character past the converted subject string is stored in <[ptr]>, if
++<[ptr]> is not <<NULL>>.
++
++If the subject string is empty (that is, if <<*>><[s]> does not start
++with a substring in acceptable form), no conversion
++is performed and the value of <[s]> is stored in <[ptr]> (if <[ptr]> is
++not <<NULL>>).
++
++The alternate function <<_wcstoul_r>> is a reentrant version.  The
++extra argument <[reent]> is a pointer to a reentrancy structure.
++
++
++RETURNS
++<<wcstoul>> returns the converted value, if any. If no conversion was
++made, <<0>> is returned.
++
++<<wcstoul>> returns <<ULONG_MAX>> if the magnitude of the converted
++value is too large, and sets <<errno>> to <<ERANGE>>.
++
++PORTABILITY
++<<wcstoul>> is ANSI.
++
++<<wcstoul>> requires no supporting OS subroutines.
++*/
++
++/*
++ * Copyright (c) 1990 Regents of the University of California.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <_ansi.h>
++#include <limits.h>
++#include <wctype.h>
++#include <wchar.h>
++#include <errno.h>
++#include <stdlib.h>
++#include <reent.h>
++
++/*
++ * Convert a wide string to an unsigned long integer.
++ *
++ * Ignores `locale' stuff.  Assumes that the upper and lower case
++ * alphabets and digits are each contiguous.
++ */
++unsigned long
++_DEFUN (_wcstoul_r, (rptr, nptr, endptr, base),
++	struct _reent *rptr _AND
++	_CONST wchar_t *nptr _AND
++	wchar_t **endptr _AND
++	int base)
++{
++	register const wchar_t *s = nptr;
++	register unsigned long acc;
++	register int c;
++	register unsigned long cutoff;
++	register int neg = 0, any, cutlim;
++
++	/*
++	 * See strtol for comments as to the logic used.
++	 */
++	do {
++		c = *s++;
++	} while (iswspace(c));
++	if (c == L'-') {
++		neg = 1;
++		c = *s++;
++	} else if (c == L'+')
++		c = *s++;
++	if ((base == 0 || base == 16) &&
++	    c == L'0' && (*s == L'x' || *s == L'X')) {
++		c = s[1];
++		s += 2;
++		base = 16;
++	}
++	if (base == 0)
++		base = c == L'0' ? 8 : 10;
++	cutoff = (unsigned long)ULONG_MAX / (unsigned long)base;
++	cutlim = (unsigned long)ULONG_MAX % (unsigned long)base;
++	for (acc = 0, any = 0;; c = *s++) {
++		if (iswdigit(c))
++			c -= L'0';
++		else if (iswalpha(c))
++			c -= iswupper(c) ? L'A' - 10 : L'a' - 10;
++		else
++			break;
++		if (c >= base)
++			break;
++               if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
++			any = -1;
++		else {
++			any = 1;
++			acc *= base;
++			acc += c;
++		}
++	}
++	if (any < 0) {
++		acc = ULONG_MAX;
++		rptr->_errno = ERANGE;
++	} else if (neg)
++		acc = -acc;
++	if (endptr != 0)
++		*endptr = (wchar_t *) (any ? s - 1 : nptr);
++	return (acc);
++}
++
++#ifndef _REENT_ONLY
++
++unsigned long
++_DEFUN (wcstoul, (s, ptr, base),
++	_CONST wchar_t *s _AND
++	wchar_t **ptr _AND
++	int base)
++{
++	return _wcstoul_r (_REENT, s, ptr, base);
++}
++
++#endif
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstoull.c b/msys/rt/src/newlib/libc/stdlib/wcstoull.c
+new file mode 100644
+index 0000000..76caadf
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstoull.c
+@@ -0,0 +1,140 @@
++/*
++FUNCTION
++	<<wcstoull>>---wide string to unsigned long long
++
++INDEX
++	wcstoull
++INDEX
++	_wcstoull_r
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++        unsigned long long wcstoull(const wchar_t *<[s]>, wchar_t **<[ptr]>,
++                              int <[base]>);
++
++        unsigned long long _wcstoull_r(void *<[reent]>, const wchar_t *<[s]>,
++                              wchar_t **<[ptr]>, int <[base]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++        unsigned long long wcstoull(<[s]>, <[ptr]>, <[base]>)
++        wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++        unsigned long long _wcstoull_r(<[reent]>, <[s]>, <[ptr]>, <[base]>)
++	wchar_t *<[reent]>;
++        wchar_t *<[s]>;
++        wchar_t **<[ptr]>;
++        int <[base]>;
++
++DESCRIPTION
++The function <<wcstoull>> converts the wide string <<*<[s]>>> to
++an <<unsigned long long>>. First, it breaks down the string into three parts:
++leading whitespace, which is ignored; a subject string consisting
++of the digits meaningful in the radix specified by <[base]>
++(for example, <<0>> through <<7>> if the value of <[base]> is 8);
++and a trailing portion consisting of one or more unparseable characters,
++which always includes the terminating null character. Then, it attempts
++to convert the subject string into an unsigned long long integer, and returns the
++result.
++
++If the value of <[base]> is zero, the subject string is expected to look
++like a normal C integer constant:  an optional sign (<<+>> or <<->>),
++a possible <<0x>> indicating hexadecimal radix or a possible <0> indicating
++octal radix, and a number.
++If <[base]> is between 2 and 36, the expected form of the subject is a
++sequence of digits (which may include letters, depending on the
++base) representing an integer in the radix specified by <[base]>.
++The letters <<a>>--<<z>> (or <<A>>--<<Z>>) are used as digits valued from
++10 to 35. If <[base]> is 16, a leading <<0x>> is permitted.
++
++The subject sequence is the longest initial sequence of the input
++string that has the expected form, starting with the first
++non-whitespace character.  If the string is empty or consists entirely
++of whitespace, or if the first non-whitespace character is not a
++permissible digit, the subject string is empty.
++
++If the subject string is acceptable, and the value of <[base]> is zero,
++<<wcstoull>> attempts to determine the radix from the input string. A
++string with a leading <<0x>> is treated as a hexadecimal value; a string with
++a leading <<0>> and no <<x>> is treated as octal; all other strings are
++treated as decimal. If <[base]> is between 2 and 36, it is used as the
++conversion radix, as described above. Finally, a pointer to the first
++character past the converted subject string is stored in <[ptr]>, if
++<[ptr]> is not <<NULL>>.
++
++If the subject string is empty (that is, if <<*>><[s]> does not start
++with a substring in acceptable form), no conversion
++is performed and the value of <[s]> is stored in <[ptr]> (if <[ptr]> is
++not <<NULL>>).
++
++The alternate function <<_wcstoull_r>> is a reentrant version.  The
++extra argument <[reent]> is a pointer to a reentrancy structure.
++
++
++RETURNS
++<<wcstoull>> returns <<0>> and sets <<errno>> to <<EINVAL>> if the value of
++<[base]> is not supported.
++
++<<wcstoull>> returns the converted value, if any. If no conversion was
++made, <<0>> is returned.
++
++<<wcstoull>> returns <<ULLONG_MAX>> if the magnitude of the converted
++value is too large, and sets <<errno>> to <<ERANGE>>.
++
++PORTABILITY
++<<wcstoull>> is ANSI.
++
++<<wcstoull>> requires no supporting OS subroutines.
++*/
++
++/*
++ * Copyright (c) 1990 Regents of the University of California.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++#include <reent.h>
++
++#ifndef _REENT_ONLY
++
++unsigned long long
++_DEFUN (wcstoull, (s, ptr, base),
++	_CONST wchar_t *s _AND
++	wchar_t **ptr _AND
++	int base)
++{
++	return _wcstoull_r (_REENT, s, ptr, base);
++}
++
++#endif
+diff --git a/msys/rt/src/newlib/libc/stdlib/wcstoull_r.c b/msys/rt/src/newlib/libc/stdlib/wcstoull_r.c
+new file mode 100644
+index 0000000..abad681
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wcstoull_r.c
+@@ -0,0 +1,130 @@
++/*
++  This code is based on wcstoul.c which has the following copyright.
++  It is used to convert a wide string into an unsigned long long.
++  
++  unsigned long long _wcstoull_r (struct _reent *rptr, const wchar_t *s,
++                                  wchar_t **ptr, int base);
++
++*/
++
++/*
++ * Copyright (c) 1990 Regents of the University of California.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#ifdef __GNUC__
++
++#define _GNU_SOURCE
++#include <_ansi.h>
++#include <limits.h>
++#include <wchar.h>
++#include <wctype.h>
++#include <errno.h>
++#include <reent.h>
++
++/* Make up for older non-compliant limits.h.  (This is a C99/POSIX function,
++ * and both require ULLONG_MAX in limits.h.)  */
++#if !defined(ULLONG_MAX)
++# define ULLONG_MAX	ULONG_LONG_MAX
++#endif
++
++/*
++ * Convert a wide string to an unsigned long long integer.
++ *
++ * Ignores `locale' stuff.  Assumes that the upper and lower case
++ * alphabets and digits are each contiguous.
++ */
++unsigned long long
++_DEFUN (_wcstoull_r, (rptr, nptr, endptr, base),
++	struct _reent *rptr _AND
++	_CONST wchar_t *nptr _AND
++	wchar_t **endptr _AND
++	int base)
++{
++	register const wchar_t *s = nptr;
++	register unsigned long long acc;
++	register int c;
++	register unsigned long long cutoff;
++	register int neg = 0, any, cutlim;
++
++	if(base < 0  ||  base == 1  ||  base > 36)  {
++		rptr->_errno = EINVAL;
++		return(0ULL);
++	}
++	/*
++	 * See strtol for comments as to the logic used.
++	 */
++	do {
++		c = *s++;
++	} while (iswspace(c));
++	if (c == L'-') {
++		neg = 1;
++		c = *s++;
++	} else if (c == L'+')
++		c = *s++;
++	if ((base == 0 || base == 16) &&
++	    c == L'0' && (*s == L'x' || *s == L'X')) {
++		c = s[1];
++		s += 2;
++		base = 16;
++	}
++	if (base == 0)
++		base = c == L'0' ? 8 : 10;
++	cutoff = (unsigned long long)ULLONG_MAX / (unsigned long long)base;
++	cutlim = (unsigned long long)ULLONG_MAX % (unsigned long long)base;
++	for (acc = 0, any = 0;; c = *s++) {
++		if (iswdigit(c))
++			c -= L'0';
++		else if (iswalpha(c))
++			c -= iswupper(c) ? L'A' - 10 : L'a' - 10;
++		else
++			break;
++		if (c >= base)
++			break;
++               if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
++			any = -1;
++		else {
++			any = 1;
++			acc *= base;
++			acc += c;
++		}
++	}
++	if (any < 0) {
++		acc = ULLONG_MAX;
++		rptr->_errno = ERANGE;
++	} else if (neg)
++		acc = -acc;
++	if (endptr != 0)
++		*endptr = (wchar_t *) (any ? s - 1 : nptr);
++	return (acc);
++}
++
++#endif /* __GNUC__ */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wctob.c b/msys/rt/src/newlib/libc/stdlib/wctob.c
+new file mode 100644
+index 0000000..d97c01f
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/stdlib/wctob.c
+@@ -0,0 +1,24 @@
++#include <reent.h>
++#include <wchar.h>
++#include <stdio.h>
++#include <string.h>
++#include <limits.h>
++#include "local.h"
++
++int
++wctob (wint_t wc)
++{
++  mbstate_t mbs;
++  unsigned char pmb[MB_LEN_MAX];
++
++  if (wc == WEOF)
++    return EOF;
++
++  /* Put mbs in initial state. */
++  memset (&mbs, '\0', sizeof (mbs));
++
++  _REENT_CHECK_MISC(_REENT);
++
++  return __wctomb (_REENT, (char *) pmb, wc, __locale_charset (), &mbs) == 1
++	  ? (int) pmb[0] : EOF;
++}
+diff --git a/msys/rt/src/newlib/libc/stdlib/wctomb.c b/msys/rt/src/newlib/libc/stdlib/wctomb.c
+index a681250..9e82eaa 100644
+--- a/msys/rt/src/newlib/libc/stdlib/wctomb.c
++++ b/msys/rt/src/newlib/libc/stdlib/wctomb.c
+@@ -16,24 +16,24 @@ TRAD_SYNOPSIS
+ 	wchar_t <[wchar]>;
+ 
+ DESCRIPTION
+-When MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
++When _MB_CAPABLE is not defined, this is a minimal ANSI-conforming 
+ implementation of <<wctomb>>.  The
+ only ``wide characters'' recognized are single bytes,
+ and they are ``converted'' to themselves.  
+ 
+-When MB_CAPABLE is defined, this routine calls <<_wctomb_r>> to perform
++When _MB_CAPABLE is defined, this routine calls <<_wctomb_r>> to perform
+ the conversion, passing a state variable to allow state dependent
+ decoding.  The result is based on the locale setting which may
+ be restricted to a defined set of locales.
+ 
+ Each call to <<wctomb>> modifies <<*<[s]>>> unless <[s]> is a null
+-pointer or MB_CAPABLE is defined and <[wchar]> is invalid.
++pointer or _MB_CAPABLE is defined and <[wchar]> is invalid.
+ 
+ RETURNS
+ This implementation of <<wctomb>> returns <<0>> if
+-<[s]> is <<NULL>>; it returns <<-1>> if MB_CAPABLE is enabled
++<[s]> is <<NULL>>; it returns <<-1>> if _MB_CAPABLE is enabled
+ and the wchar is not a valid multi-byte character, it returns <<1>>
+-if MB_CAPABLE is not defined or the wchar is in reality a single
++if _MB_CAPABLE is not defined or the wchar is in reality a single
+ byte character, otherwise it returns the number of bytes in the
+ multi-byte character.
+ 
+@@ -46,24 +46,34 @@ effects vary with the locale.
+ 
+ #ifndef _REENT_ONLY
+ 
++#include <newlib.h>
+ #include <stdlib.h>
++#include <errno.h>
++#include "local.h"
+ 
+ int
+ _DEFUN (wctomb, (s, wchar),
+         char *s _AND
+         wchar_t wchar)
+ {
+-#ifdef MB_CAPABLE
+-        static int state;
++#ifdef _MB_CAPABLE
++        _REENT_CHECK_MISC(_REENT);
+ 
+-        return _wctomb_r (_REENT, s, wchar, &state);
+-#else /* not MB_CAPABLE */
++        return __wctomb (_REENT, s, wchar, __locale_charset (),
++			 &(_REENT_WCTOMB_STATE(_REENT)));
++#else /* not _MB_CAPABLE */
+         if (s == NULL)
+                 return 0;
+ 
++	/* Verify that wchar is a valid single-byte character.  */
++	if ((size_t)wchar >= 0x100) {
++		errno = EILSEQ;
++		return -1;
++	}
++
+         *s = (char) wchar;
+         return 1;
+-#endif /* not MB_CAPABLE */
++#endif /* not _MB_CAPABLE */
+ }
+ 
+ #endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/stdlib/wctomb_r.c b/msys/rt/src/newlib/libc/stdlib/wctomb_r.c
+index b382c99..54d0106 100644
+--- a/msys/rt/src/newlib/libc/stdlib/wctomb_r.c
++++ b/msys/rt/src/newlib/libc/stdlib/wctomb_r.c
+@@ -1,111 +1,376 @@
++#include <errno.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <wchar.h>
+ #include <locale.h>
+ #include "mbctype.h"
++#include "local.h"
++
++int (*__wctomb) (struct _reent *, char *, wchar_t, const char *charset,
++		 mbstate_t *)
++#if defined(__CYGWIN__) || defined(__MSYS__)
++   /* Cygwin starts up in UTF-8 mode. */
++    = __utf8_wctomb;
++#else
++    = __ascii_wctomb;
++#endif
+ 
+ int
+ _DEFUN (_wctomb_r, (r, s, wchar, state),
+         struct _reent *r     _AND 
+         char          *s     _AND
+-        wchar_t        wchar _AND
+-        int           *state)
++        wchar_t        _wchar _AND
++        mbstate_t     *state)
++{
++  return __wctomb (r, s, _wchar, __locale_charset (), state);
++}
++
++int
++_DEFUN (__ascii_wctomb, (r, s, wchar, charset, state),
++        struct _reent *r       _AND 
++        char          *s       _AND
++        wchar_t        _wchar  _AND
++	const char    *charset _AND
++        mbstate_t     *state)
+ {
+-  if (strlen (r->_current_locale) <= 1)
+-    { /* fall-through */ }
+-  else if (!strcmp (r->_current_locale, "C-SJIS"))
++  /* Avoids compiler warnings about comparisons that are always false
++     due to limited range when sizeof(wchar_t) is 2 but sizeof(wint_t)
++     is 4, as is the case on cygwin.  */
++  wint_t wchar = _wchar;
++
++  if (s == NULL)
++    return 0;
++ 
++#if defined(__CYGWIN__) || defined(__MSYS__)
++  if ((size_t)wchar >= 0x80)
++#else
++  if ((size_t)wchar >= 0x100)
++#endif
++    {
++      r->_errno = EILSEQ;
++      return -1;
++    }
++
++  *s = (char) wchar;
++  return 1;
++}
++
++#ifdef _MB_CAPABLE
++/* for some conversions, we use the __count field as a place to store a state value */
++#define __state __count
++
++int
++_DEFUN (__utf8_wctomb, (r, s, wchar, charset, state),
++        struct _reent *r       _AND 
++        char          *s       _AND
++        wchar_t        _wchar  _AND
++	const char    *charset _AND
++        mbstate_t     *state)
++{
++  wint_t wchar = _wchar;
++  int ret = 0;
++
++  if (s == NULL)
++    return 0; /* UTF-8 encoding is not state-dependent */
++
++  if (sizeof (wchar_t) == 2 && state->__count == -4
++      && (wchar < 0xdc00 || wchar >= 0xdfff))
++    {
++      /* There's a leftover lone high surrogate.  Write out the CESU-8 value
++	 of the surrogate and proceed to convert the given character.  Note
++	 to return extra 3 bytes. */
++      wchar_t tmp;
++      tmp = (state->__value.__wchb[0] << 16 | state->__value.__wchb[1] << 8)
++	    - 0x10000 >> 10 | 0xd80d;
++      *s++ = 0xe0 | ((tmp & 0xf000) >> 12);
++      *s++ = 0x80 | ((tmp &  0xfc0) >> 6);
++      *s++ = 0x80 |  (tmp &   0x3f);
++      state->__count = 0;
++      ret = 3;
++    }
++  if (wchar <= 0x7f)
++    {
++      *s = wchar;
++      return ret + 1;
++    }
++  if (wchar >= 0x80 && wchar <= 0x7ff)
+     {
+-      unsigned char char2 = (unsigned char)wchar;
+-      unsigned char char1 = (unsigned char)(wchar >> 8);
+-
+-      if (s == NULL)
+-        return 0;  /* not state-dependent */
+-
+-      if (char1 != 0x00)
+-        {
+-        /* first byte is non-zero..validate multi-byte char */
+-          if (_issjis1(char1) && _issjis2(char2)) 
+-            {
+-              *s++ = (char)char1;
+-              *s = (char)char2;
+-              return 2;
+-            }
+-          else
+-            return -1;
+-        }
++      *s++ = 0xc0 | ((wchar & 0x7c0) >> 6);
++      *s   = 0x80 |  (wchar &  0x3f);
++      return ret + 2;
+     }
+-  else if (!strcmp (r->_current_locale, "C-EUCJP"))
++  if (wchar >= 0x800 && wchar <= 0xffff)
+     {
+-      unsigned char char2 = (unsigned char)wchar;
+-      unsigned char char1 = (unsigned char)(wchar >> 8);
+-
+-      if (s == NULL)
+-        return 0;  /* not state-dependent */
+-
+-      if (char1 != 0x00)
+-        {
+-        /* first byte is non-zero..validate multi-byte char */
+-          if (_iseucjp (char1) && _iseucjp (char2)) 
+-            {
+-              *s++ = (char)char1;
+-              *s = (char)char2;
+-              return 2;
+-            }
+-          else
+-            return -1;
+-        }
++      /* No UTF-16 surrogate handling in UCS-4 */
++      if (sizeof (wchar_t) == 2 && wchar >= 0xd800 && wchar <= 0xdfff)
++	{
++	  wint_t tmp;
++	  if (wchar <= 0xdbff)
++	    {
++	      /* First half of a surrogate pair.  Store the state and
++	         return ret + 0. */
++	      tmp = ((wchar & 0x3ff) << 10) + 0x10000;
++	      state->__value.__wchb[0] = (tmp >> 16) & 0xff;
++	      state->__value.__wchb[1] = (tmp >> 8) & 0xff;
++	      state->__count = -4;
++	      *s = (0xf0 | ((tmp & 0x1c0000) >> 18));
++	      return ret;
++	    }
++	  if (state->__count == -4)
++	    {
++	      /* Second half of a surrogate pair.  Reconstruct the full
++		 Unicode value and return the trailing three bytes of the
++		 UTF-8 character. */
++	      tmp = (state->__value.__wchb[0] << 16)
++		    | (state->__value.__wchb[1] << 8)
++		    | (wchar & 0x3ff);
++	      state->__count = 0;
++	      *s++ = 0xf0 | ((tmp & 0x1c0000) >> 18);
++	      *s++ = 0x80 | ((tmp &  0x3f000) >> 12);
++	      *s++ = 0x80 | ((tmp &    0xfc0) >> 6);
++	      *s   = 0x80 |  (tmp &     0x3f);
++	      return 4;
++	    }
++	  /* Otherwise translate into CESU-8 value. */
++	}
++      *s++ = 0xe0 | ((wchar & 0xf000) >> 12);
++      *s++ = 0x80 | ((wchar &  0xfc0) >> 6);
++      *s   = 0x80 |  (wchar &   0x3f);
++      return ret + 3;
+     }
+-  else if (!strcmp (r->_current_locale, "C-JIS"))
++  if (wchar >= 0x10000 && wchar <= 0x10ffff)
+     {
+-      int cnt = 0; 
+-      unsigned char char2 = (unsigned char)wchar;
+-      unsigned char char1 = (unsigned char)(wchar >> 8);
+-
+-      if (s == NULL)
+-        return 1;  /* state-dependent */
+-
+-      if (char1 != 0x00)
+-        {
+-        /* first byte is non-zero..validate multi-byte char */
+-          if (_isjis (char1) && _isjis (char2)) 
+-            {
+-              if (*state == 0)
+-                {
+-                  /* must switch from ASCII to JIS state */
+-                  *state = 1;
+-                  *s++ = ESC_CHAR;
+-                  *s++ = '$';
+-                  *s++ = 'B';
+-                  cnt = 3;
+-                }
+-              *s++ = (char)char1;
+-              *s = (char)char2;
+-              return cnt + 2;
+-            }
+-          else
+-            return -1;
+-        }
++      *s++ = 0xf0 | ((wchar & 0x1c0000) >> 18);
++      *s++ = 0x80 | ((wchar &  0x3f000) >> 12);
++      *s++ = 0x80 | ((wchar &    0xfc0) >> 6);
++      *s   = 0x80 |  (wchar &     0x3f);
++      return 4;
++    }
++
++  r->_errno = EILSEQ;
++  return -1;
++}
++
++/* Cygwin defines its own doublebyte charset conversion functions 
++   because the underlying OS requires wchar_t == UTF-16. */
++#if !defined(__CYGWIN__) && !defined(__MSYS__)
++int
++_DEFUN (__sjis_wctomb, (r, s, wchar, charset, state),
++        struct _reent *r       _AND 
++        char          *s       _AND
++        wchar_t        _wchar  _AND
++	const char    *charset _AND
++        mbstate_t     *state)
++{
++  wint_t wchar = _wchar;
++
++  unsigned char char2 = (unsigned char)wchar;
++  unsigned char char1 = (unsigned char)(wchar >> 8);
++
++  if (s == NULL)
++    return 0;  /* not state-dependent */
++
++  if (char1 != 0x00)
++    {
++    /* first byte is non-zero..validate multi-byte char */
++      if (_issjis1(char1) && _issjis2(char2)) 
++	{
++	  *s++ = (char)char1;
++	  *s = (char)char2;
++	  return 2;
++	}
+       else
+-        {
+-          if (*state != 0)
+-            {
+-              /* must switch from JIS to ASCII state */
+-              *state = 0;
+-              *s++ = ESC_CHAR;
+-              *s++ = '(';
+-              *s++ = 'B';
+-              cnt = 3;
+-            }
+-          *s = (char)char2;
+-          return cnt + 1;
+-        }
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
+     }
++  *s = (char) wchar;
++  return 1;
++}
++
++int
++_DEFUN (__eucjp_wctomb, (r, s, wchar, charset, state),
++        struct _reent *r       _AND 
++        char          *s       _AND
++        wchar_t        _wchar  _AND
++	const char    *charset _AND
++        mbstate_t     *state)
++{
++  wint_t wchar = _wchar;
++  unsigned char char2 = (unsigned char)wchar;
++  unsigned char char1 = (unsigned char)(wchar >> 8);
++
++  if (s == NULL)
++    return 0;  /* not state-dependent */
++
++  if (char1 != 0x00)
++    {
++    /* first byte is non-zero..validate multi-byte char */
++      if (_iseucjp1 (char1) && _iseucjp2 (char2)) 
++	{
++	  *s++ = (char)char1;
++	  *s = (char)char2;
++	  return 2;
++	}
++      else if (_iseucjp2 (char1) && _iseucjp2 (char2 | 0x80))
++	{
++	  *s++ = (char)0x8f;
++	  *s++ = (char)char1;
++	  *s = (char)(char2 | 0x80);
++	  return 3;
++	}
++      else
++	{
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++    }
++  *s = (char) wchar;
++  return 1;
++}
++
++int
++_DEFUN (__jis_wctomb, (r, s, wchar, charset, state),
++        struct _reent *r       _AND 
++        char          *s       _AND
++        wchar_t        _wchar  _AND
++	const char    *charset _AND
++        mbstate_t     *state)
++{
++  wint_t wchar = _wchar;
++  int cnt = 0; 
++  unsigned char char2 = (unsigned char)wchar;
++  unsigned char char1 = (unsigned char)(wchar >> 8);
++
++  if (s == NULL)
++    return 1;  /* state-dependent */
++
++  if (char1 != 0x00)
++    {
++    /* first byte is non-zero..validate multi-byte char */
++      if (_isjis (char1) && _isjis (char2)) 
++	{
++	  if (state->__state == 0)
++	    {
++	      /* must switch from ASCII to JIS state */
++	      state->__state = 1;
++	      *s++ = ESC_CHAR;
++	      *s++ = '$';
++	      *s++ = 'B';
++	      cnt = 3;
++	    }
++	  *s++ = (char)char1;
++	  *s = (char)char2;
++	  return cnt + 2;
++	}
++      r->_errno = EILSEQ;
++      return -1;
++    }
++  if (state->__state != 0)
++    {
++      /* must switch from JIS to ASCII state */
++      state->__state = 0;
++      *s++ = ESC_CHAR;
++      *s++ = '(';
++      *s++ = 'B';
++      cnt = 3;
++    }
++  *s = (char)char2;
++  return cnt + 1;
++}
++#endif /* !__CYGWIN__ */
++
++#ifdef _MB_EXTENDED_CHARSETS_ISO
++int
++_DEFUN (__iso_wctomb, (r, s, wchar, charset, state),
++        struct _reent *r       _AND 
++        char          *s       _AND
++        wchar_t        _wchar  _AND
++	const char    *charset _AND
++        mbstate_t     *state)
++{
++  wint_t wchar = _wchar;
+ 
+   if (s == NULL)
+     return 0;
++
++  /* wchars <= 0x9f translate to all ISO charsets directly. */
++  if (wchar >= 0xa0)
++    {
++      int iso_idx = __iso_8859_index (charset + 9);
++      if (iso_idx >= 0)
++	{
++	  unsigned char mb;
++
++	  if (s == NULL)
++	    return 0;
++
++	  for (mb = 0; mb < 0x60; ++mb)
++	    if (__iso_8859_conv[iso_idx][mb] == wchar)
++	      {
++		*s = (char) (mb + 0xa0);
++		return 1;
++	      }
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++    }
+  
+-  /* otherwise we are dealing with a single byte character */
++  if ((size_t)wchar >= 0x100)
++    {
++      r->_errno = EILSEQ;
++      return -1;
++    }
++
+   *s = (char) wchar;
+   return 1;
+ }
+-    
++#endif /* _MB_EXTENDED_CHARSETS_ISO */
++
++#ifdef _MB_EXTENDED_CHARSETS_WINDOWS
++int
++_DEFUN (__cp_wctomb, (r, s, wchar, charset, state),
++        struct _reent *r       _AND 
++        char          *s       _AND
++        wchar_t        _wchar  _AND
++	const char    *charset _AND
++        mbstate_t     *state)
++{
++  wint_t wchar = _wchar;
++
++  if (s == NULL)
++    return 0;
+ 
++  if (wchar >= 0x80)
++    {
++      int cp_idx = __cp_index (charset + 2);
++      if (cp_idx >= 0)
++	{
++	  unsigned char mb;
++
++	  if (s == NULL)
++	    return 0;
++
++	  for (mb = 0; mb < 0x80; ++mb)
++	    if (__cp_conv[cp_idx][mb] == wchar)
++	      {
++		*s = (char) (mb + 0x80);
++		return 1;
++	      }
++	  r->_errno = EILSEQ;
++	  return -1;
++	}
++    }
++
++  if ((size_t)wchar >= 0x100)
++    {
++      r->_errno = EILSEQ;
++      return -1;
++    }
++
++  *s = (char) wchar;
++  return 1;
++}
++#endif /* _MB_EXTENDED_CHARSETS_WINDOWS */
++#endif /* _MB_CAPABLE */
+diff --git a/msys/rt/src/newlib/libc/string/Makefile.in b/msys/rt/src/newlib/libc/string/Makefile.in
+index 8139a57..79fd00c 100644
+--- a/msys/rt/src/newlib/libc/string/Makefile.in
++++ b/msys/rt/src/newlib/libc/string/Makefile.in
+@@ -122,8 +122,27 @@ lib_a_SOURCES = \
+ 	strxfrm.c  \
+ 	strstr.c \
+ 	swab.c \
+-	u_strerr.c
+-
++	u_strerr.c \
++	wcscasecmp.c \
++	wcschr.c \
++	wcscoll.c \
++	wcsdup.c \
++	wcsncasecmp.c \
++	wcsncmp.c \
++	wcsrchr.c \
++	wcwidth.c \
++	wcscat.c \
++	wcscmp.c \
++	wcscpy.c \
++	wcslen.c \
++	wcsncat.c \
++	wcsncpy.c \
++	wcswidth.c \
++	wmemchr.c \
++	wmemcmp.c \
++	wmemcpy.c \
++	wmemmove.c \
++	wmemset.c
+ 
+ CHEWOUT_FILES = \
+ bcmp.def	memcpy.def	strcmp.def	strncat.def strstr.def \
+@@ -156,7 +175,12 @@ lib_a_OBJECTS =  bcmp.o bcopy.o bzero.o index.o memchr.o memcmp.o \
+ memcpy.o memmove.o memset.o rindex.o strcat.o strchr.o strcmp.o \
+ strcasecmp.o strcoll.o strcpy.o strcspn.o strerror.o strlen.o strlwr.o \
+ strncat.o strncmp.o strncasecmp.o strncpy.o strpbrk.o strrchr.o \
+-strspn.o strtok.o strtok_r.o strupr.o strxfrm.o strstr.o swab.o u_strerr.o
++strspn.o strtok.o strtok_r.o strupr.o strxfrm.o strstr.o swab.o u_strerr.o \
++wcscasecmp.o wcschr.o wcscoll.o wcsdup.o wcsncasecmp.o wcsncmp.o wcsrchr.o \
++wcwidth.o wcscat.o wcscmp.o wcscpy.o wcslen.o wcsncat.o wcsncpy.o wcswidth.o \
++wmemchr.o wmemcmp.o wmemcpy.o wmemmove.o wmemset.o
++
++
+ CFLAGS = @CFLAGS@
+ COMPILE = $(CC) $(DEFS) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+ CCLD = $(CC)
+diff --git a/msys/rt/src/newlib/libc/string/local.h b/msys/rt/src/newlib/libc/string/local.h
+new file mode 100644
+index 0000000..d8a2b1e
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/local.h
+@@ -0,0 +1,12 @@
++#include <_ansi.h>
++#include "../ctype/local.h"
++
++/* internal function to compute width of wide char. */
++int _EXFUN (__wcwidth, (wint_t));
++
++/* Defined in locale/locale.c.  Returns a value != 0 if the current
++   language is assumed to use CJK fonts. */
++/*
++int __locale_cjk_lang ();
++*/
++#define __locale_cjk_lang() 0
+diff --git a/msys/rt/src/newlib/libc/string/wcscasecmp.c b/msys/rt/src/newlib/libc/string/wcscasecmp.c
+new file mode 100644
+index 0000000..f9f169f
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcscasecmp.c
+@@ -0,0 +1,56 @@
++/*
++FUNCTION
++	<<wcscasecmp>>---case-insensitive wide character string compare
++	
++INDEX
++	wcscasecmp
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wcscasecmp(const wchar_t *<[a]>, const wchar_t *<[b]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	int wcscasecmp(<[a]>, <[b]>)
++	wchar_t *<[a]>;
++	wchar_t *<[b]>;
++
++DESCRIPTION
++	<<wcscasecmp>> compares the wide character string at <[a]> to
++	the wide character string at <[b]> in a case-insensitive manner.
++
++RETURNS 
++
++	If <<*<[a]>>> sorts lexicographically after <<*<[b]>>> (after
++	both are converted to uppercase), <<wcscasecmp>> returns a
++	number greater than zero.  If the two strings match,
++	<<wcscasecmp>> returns zero.  If <<*<[a]>>> sorts
++	lexicographically before <<*<[b]>>>, <<wcscasecmp>> returns a
++	number less than zero.
++
++PORTABILITY
++POSIX-1.2008
++
++<<wcscasecmp>> requires no supporting OS subroutines. It uses
++tolower() from elsewhere in this library.
++
++QUICKREF
++	wcscasecmp 
++*/
++
++#include <wchar.h>
++#include <wctype.h>
++
++int
++_DEFUN (wcscasecmp, (s1, s2),
++	_CONST wchar_t *s1 _AND
++	_CONST wchar_t *s2)
++{
++  while (*s1 != '\0' && towlower(*s1) == towlower(*s2))
++    {
++      s1++;
++      s2++;
++    }
++
++  return towlower(*s1) - towlower(*s2);
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcscat.c b/msys/rt/src/newlib/libc/string/wcscat.c
+new file mode 100644
+index 0000000..54c0b50
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcscat.c
+@@ -0,0 +1,85 @@
++/*
++FUNCTION
++	<<wcscat>>---concatenate two wide-character strings
++INDEX
++	wcscat
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcscat(wchar_t *<[s1]>, const wchar_t *<[s2]>);
++
++TRAD_SYNOPSIS
++	wchar_t *wcscat(<[s1]>, <[s2]>
++	wchar_t *<[s1]>;
++	const wchar_t *<[s2]>;
++
++DESCRIPTION
++	The <<wcscat>> function appends a copy of the wide-character string
++	pointed to by <[s2]> (including the terminating null wide-character
++	code) to the end of the wide-character string pointed to by <[s1]>.
++	The initial wide-character code of <[s2]> overwrites the null
++	wide-character code at the end of <[s1]>. If copying takes place between
++	objects that overlap, the behaviour is undefined. 
++
++RETURNS
++	The <<wcscat>> function returns <[s1]>;
++	no return value is reserved to indicate an error. 
++
++PORTABILITY
++<<wcscat>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wcscat.c,v 1.1 2000/12/23 23:14:36 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wcscat.c,v 1.1 1999/12/29 21:47:45 tshiozak Exp
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wcscat, (s1, s2),
++	wchar_t * s1 _AND
++	_CONST wchar_t * s2)
++{
++  wchar_t *p;
++  wchar_t *q;
++  _CONST wchar_t *r;
++
++  p = s1;
++  while (*p)
++    p++;
++  q = p;
++  r = s2;
++  while (*r)
++    *q++ = *r++;
++  *q = '\0';
++  return s1;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcschr.c b/msys/rt/src/newlib/libc/string/wcschr.c
+new file mode 100644
+index 0000000..fb35d1f
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcschr.c
+@@ -0,0 +1,82 @@
++/*
++FUNCTION
++	<<wcschr>>---wide-character string scanning operation
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcschr(const wchar_t *<[s]>, wchar_t <[c]>);
++
++TRAD_SYNOPSIS
++	wchar_t *wcschr(<[s]>, <[c]>
++	const wchar_t *<[s]>;
++	wchar_t <[c]>;
++
++DESCRIPTION
++	The <<wcschr>> function locates the first occurrence of <[c]> in the
++	wide-character string pointed to by <[s]>. The value of <[c]> must be a
++	character representable as a type wchar_t and must be a wide-character
++	code corresponding to a valid character in the current locale.
++	The terminating null wide-character string.
++
++RETURNS
++	Upon completion, <<wcschr>> returns a pointer to the wide-character
++	code, or a null pointer if the wide-character code is not found. 
++
++PORTABILITY
++<<wcschr>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wcschr.c,v 1.1 2000/12/23 23:14:36 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wcschr.c,v 1.2 2000/12/21 05:07:25 itojun Exp
++ */
++
++#include <_ansi.h>
++#include <stddef.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wcschr, (s, c),
++	_CONST wchar_t * s _AND
++	wchar_t c)
++{
++  _CONST wchar_t *p;
++
++  p = s;
++  do
++    {
++      if (*p == c)
++	{
++	  /* LINTED interface specification */
++	  return (wchar_t *) p;
++	}
++    } while (*p++);
++  return NULL;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcscmp.c b/msys/rt/src/newlib/libc/string/wcscmp.c
+new file mode 100644
+index 0000000..0308962
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcscmp.c
+@@ -0,0 +1,83 @@
++/*
++FUNCTION
++	<<wcscmp>>---compare two wide-character strings
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wcscmp(const wchar_t *<[s1]>, *<[s2]>);
++
++TRAD_SYNOPSIS
++	int wcscmp(<[s1]>, <[s2]>
++	const wchar_t *<[s1]>, <[s2]>;
++
++DESCRIPTION
++	The <<wcscmp>> function compares the wide-character string pointed to
++	by <[s1]> to the wide-character string pointed to by <[s2]>.
++
++	The sign of a non-zero return value is determined by the sign of the
++	difference between the values of the first pair of wide-character codes
++	that differ in the objects being compared.
++
++RETURNS
++	Upon completion, <<wcscmp>> returns an integer greater than, equal to
++	or less than 0, if the wide-character string pointed to by <[s1]> is
++	greater than, equal to or less than the wide-character string pointed
++	to by <[s2]> respectively. 
++
++PORTABILITY
++<<wcscmp>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD$	*/
++
++/*-
++ * Copyright (c) 1990, 1993
++ *	The Regents of the University of California.  All rights reserved.
++ *
++ * This code is derived from software contributed to Berkeley by
++ * Chris Torek.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++/*
++ * Compare strings.
++ */
++int
++_DEFUN (wcscmp, (s1, s2),
++	_CONST wchar_t * s1 _AND
++	_CONST wchar_t * s2)
++{
++
++  while (*s1 == *s2++)
++    if (*s1++ == 0)
++      return (0);
++  return (*s1 - *--s2);
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcscoll.c b/msys/rt/src/newlib/libc/string/wcscoll.c
+new file mode 100644
+index 0000000..0f0513a
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcscoll.c
+@@ -0,0 +1,48 @@
++/*
++FUNCTION
++	<<wcscoll>>---locale-specific wide-character string compare
++	
++INDEX
++	wcscoll
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wcscoll(const wchar_t *<[stra]>, const wchar_t * <[strb]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	int wcscoll(<[stra]>, <[strb]>)
++	wchar_t *<[stra]>;
++	wchar_t *<[strb]>;
++
++DESCRIPTION
++	<<wcscoll>> compares the wide-character string pointed to by
++	<[stra]> to the wide-character string pointed to by <[strb]>,
++	using an interpretation appropriate to the current <<LC_COLLATE>>
++	state.
++
++	The current implementation of <<wcscoll>> simply uses <<wcscmp>>
++	and does not support any language-specific sorting.
++
++RETURNS
++	If the first string is greater than the second string,
++	<<wcscoll>> returns a number greater than zero.  If the two
++	strings are equivalent, <<wcscoll>> returns zero.  If the first
++	string is less than the second string, <<wcscoll>> returns a
++	number less than zero.
++
++PORTABILITY
++<<wcscoll>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++*/
++
++#include <_ansi.h>
++#include <wchar.h>
++
++int
++_DEFUN (wcscoll, (a, b),
++	_CONST wchar_t *a _AND
++	_CONST wchar_t *b)
++
++{
++  return wcscmp (a, b);
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcscpy.c b/msys/rt/src/newlib/libc/string/wcscpy.c
+new file mode 100644
+index 0000000..ede693d
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcscpy.c
+@@ -0,0 +1,79 @@
++/*
++FUNCTION
++	<<wcscpy>>---copy a wide-character string 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcscpy(wchar_t *<[s1]>, const wchar_t *,<[s2]>);
++
++TRAD_SYNOPSIS
++	wchar_t *wcscpy(<[s1]>, <[s2]>
++	wchar_t *<[s1]>;
++	const wchar_t *<[s2]>;
++
++DESCRIPTION
++	The <<wcscpy>> function copies the wide-character string pointed to by
++	<[s2]> (including the terminating null wide-character code) into the
++	array pointed to by <[s1]>. If copying takes place between objects that
++	overlap, the behaviour is undefined. 
++
++RETURNS
++	The <<wcscpy>> function returns <[s1]>; no return value is reserved to
++	indicate an error. 
++
++PORTABILITY
++<<wcscpy>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wcscpy.c,v 1.1 2000/12/23 23:14:36 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wcscpy.c,v 1.2 2000/12/21 04:51:09 itojun Exp
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wcscpy, (s1, s2),
++	wchar_t * s1 _AND
++	_CONST wchar_t * s2)
++{
++  wchar_t *p;
++  _CONST wchar_t *q;
++
++  *s1 = '\0';
++  p = s1;
++  q = s2;
++  while (*q)
++    *p++ = *q++;
++  *p = '\0';
++
++  return s1;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcsdup.c b/msys/rt/src/newlib/libc/string/wcsdup.c
+new file mode 100644
+index 0000000..90be68e
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcsdup.c
+@@ -0,0 +1,62 @@
++/*
++FUNCTION
++	<<wcsdup>>---wide character string duplicate
++	
++INDEX
++	wcsdup
++INDEX
++	_wcsdup_r
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcsdup(const wchar_t *<[str]>);
++
++	#include <wchar.h>
++	wchar_t *_wcsdup_r(struct _reent *<[ptr]>, const wchar_t *<[str]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcsdup(<[ptr]>, <[str]>)
++	struct _reent *<[ptr]>;
++	wchar_t *<[str]>;
++
++DESCRIPTION
++	<<wcsdup>> allocates a new wide character string using <<malloc>>,
++	and copies the content of the argument <[str]> into the newly
++	allocated string, thus making a copy of <[str]>.
++
++RETURNS 
++	<<wcsdup>> returns a pointer to the copy of <[str]> if enough
++	memory for the copy was available.  Otherwise it returns NULL
++	and errno is set to ENOMEM.
++
++PORTABILITY
++POSIX-1.2008
++
++QUICKREF
++	wcsdup 
++*/
++
++#include <reent.h>
++#include <stdlib.h>
++#include <wchar.h>
++
++wchar_t *
++_wcsdup_r (struct _reent *p, const wchar_t *str)
++{
++  size_t len = wcslen (str) + 1;
++  wchar_t *copy = _malloc_r (p, len * sizeof (wchar_t));
++  if (copy)
++    wmemcpy (copy, str, len);
++  return copy;
++}
++
++#ifndef _REENT_ONLY
++
++wchar_t *
++wcsdup (const wchar_t *str)
++{
++  return _wcsdup_r (_REENT, str);
++}
++
++#endif /* !_REENT_ONLY */
+diff --git a/msys/rt/src/newlib/libc/string/wcslen.c b/msys/rt/src/newlib/libc/string/wcslen.c
+new file mode 100644
+index 0000000..d671551
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcslen.c
+@@ -0,0 +1,72 @@
++/*
++FUNCTION
++	<<wcslen>>---get wide-character string length 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	size_t wcslen(const wchar_t *<[s]>);
++
++TRAD_SYNOPSIS
++	size_t wcslen(<[s]>
++	const wchar_t *<[s]>;
++
++DESCRIPTION
++	The <<wcslen>> function computes the number of wide-character codes
++	in the wide-character string to which <[s]> points, not including the
++	terminating null wide-character code.
++
++RETURNS
++	The <<wcslen>> function returns the length of <[s]>; no return value is
++	reserved to indicate an error.
++
++PORTABILITY
++<<wcslen>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wcslen.c,v 1.1 2000/12/23 23:14:36 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wcslen.c,v 1.1 1999/12/29 21:47:45 tshiozak Exp
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++size_t
++_DEFUN (wcslen, (s),
++	_CONST wchar_t * s)
++{
++  _CONST wchar_t *p;
++
++  p = s;
++  while (*p)
++    p++;
++
++  return p - s;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcsncasecmp.c b/msys/rt/src/newlib/libc/string/wcsncasecmp.c
+new file mode 100644
+index 0000000..1634ca1
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcsncasecmp.c
+@@ -0,0 +1,64 @@
++/*
++FUNCTION
++	<<wcsncasecmp>>---case-insensitive wide character string compare
++	
++INDEX
++	wcsncasecmp
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wcsncasecmp(const wchar_t *<[a]>, const wchar_t * <[b]>, size_t <[length]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	int wcsncasecmp(<[a]>, <[b]>, <[length]>)
++	wchar_t *<[a]>;
++	wchar_t *<[b]>;
++	size_t <[length]>
++
++DESCRIPTION
++	<<wcsncasecmp>> compares up to <[length]> wide characters
++	from the string at <[a]> to the string at <[b]> in a 
++	case-insensitive manner.
++
++RETURNS
++
++	If <<*<[a]>>> sorts lexicographically after <<*<[b]>>> (after
++	both are converted to uppercase), <<wcsncasecmp>> returns a
++	number greater than zero.  If the two strings are equivalent,
++	<<wcsncasecmp>> returns zero.  If <<*<[a]>>> sorts
++	lexicographically before <<*<[b]>>>, <<wcsncasecmp>> returns a
++	number less than zero.
++
++PORTABILITY
++POSIX-1.2008
++
++<<wcsncasecmp>> requires no supporting OS subroutines. It uses
++tolower() from elsewhere in this library.
++
++QUICKREF
++	wcsncasecmp
++*/
++
++#include <wchar.h>
++#include <wctype.h>
++
++int 
++_DEFUN (wcsncasecmp, (s1, s2, n),
++	_CONST wchar_t *s1 _AND
++	_CONST wchar_t *s2 _AND
++	size_t n)
++{
++  if (n == 0)
++    return 0;
++
++  while (n-- != 0 && towlower(*s1) == towlower(*s2))
++    {
++      if (n == 0 || *s1 == '\0' || *s2 == '\0')
++	break;
++      s1++;
++      s2++;
++    }
++
++  return towlower(*s1) - towlower(*s2);
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcsncat.c b/msys/rt/src/newlib/libc/string/wcsncat.c
+new file mode 100644
+index 0000000..fd77c0c
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcsncat.c
+@@ -0,0 +1,91 @@
++/*
++FUNCTION
++	<<wcsncat>>---concatenate part of two wide-character strings 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcsncat(wchar_t *<[s1]>, const wchar_t *<[s2]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	wchar_t *wcsncat(<[s1]>, <[s2]>, <[n]>
++	wchar_t *<[s1]>;
++	const wchar_t *<[s2]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wcsncat>> function appends not more than <[n]> wide-character
++	codes (a null wide-character code and wide-character codes that follow
++	it are not appended) from the array pointed to by <[s2]> to the end of
++	the wide-character string pointed to by <[s1]>. The initial
++	wide-character code of <[s2]> overwrites the null wide-character code
++	at the end of <[s1]>.
++	A terminating null wide-character code is always appended to the result.
++	If copying takes place between objects that overlap, the behaviour is
++	undefined.
++
++RETURNS
++	The <<wcsncat>> function returns <[s1]>; no return value is reserved to
++	indicate an error.
++
++PORTABILITY
++<<wcsncat>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wcsncat.c,v 1.1 2000/12/23 23:14:36 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wcsncat.c,v 1.1 1999/12/29 21:47:45 tshiozak Exp
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wcsncat, (s1, s2, n),
++	wchar_t * s1 _AND
++	_CONST wchar_t * s2 _AND
++	size_t n)
++{
++  wchar_t *p;
++  wchar_t *q;
++  _CONST wchar_t *r;
++
++  p = s1;
++  while (*p)
++    p++;
++  q = p;
++  r = s2;
++  while (*r && n)
++    {
++      *q++ = *r++;
++      n--;
++    }
++  *q = '\0';
++  return s1;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcsncmp.c b/msys/rt/src/newlib/libc/string/wcsncmp.c
+new file mode 100644
+index 0000000..1897f5c
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcsncmp.c
+@@ -0,0 +1,91 @@
++/*
++FUNCTION
++	<<wcsncmp>>---compare part of two wide-character strings 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wcsncmp(const wchar_t *<[s1]>, const wchar_t *<[s2]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	int wcsncmp(<[s1]>, <[s2]>, <[n]>
++	const wchar_t *<[s1]>;
++	const wchar_t *<[s2]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wcsncmp>> function compares not more than <[n]> wide-character
++	codes (wide-character codes that follow a null wide-character code are
++	not compared) from the array pointed to by <[s1]> to the array pointed
++	to by <[s2]>.
++
++	The sign of a non-zero return value is determined by the sign of the
++	difference between the values of the first pair of wide-character codes
++	that differ in the objects being compared. 
++
++RETURNS
++	Upon successful completion, <<wcsncmp>> returns an integer greater than,
++	equal to or less than 0, if the possibly null-terminated array pointed
++	to by <[s1]> is greater than, equal to or less than the possibly
++	null-terminated array pointed to by <[s2]> respectively. 
++
++PORTABILITY
++<<wcsncmp>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD$	*/
++
++/*
++ * Copyright (c) 1989, 1993
++ *	The Regents of the University of California.  All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++int
++_DEFUN (wcsncmp, (s1, s2, n),
++	_CONST wchar_t * s1 _AND
++	_CONST wchar_t * s2 _AND
++	size_t n)
++{
++
++  if (n == 0)
++    return (0);
++  do
++    {
++      if (*s1 != *s2++)
++	{
++	  return (*s1 - *--s2);
++	}
++      if (*s1++ == 0)
++	break;
++    }
++  while (--n != 0);
++  return (0);
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcsncpy.c b/msys/rt/src/newlib/libc/string/wcsncpy.c
+new file mode 100644
+index 0000000..533b0ce
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcsncpy.c
+@@ -0,0 +1,58 @@
++/*
++FUNCTION
++	<<wcsncpy>>---copy part of a wide-character string 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcsncpy(wchar_t *<[s1]>, const wchar_t *<[s2]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	wchar_t *wcsncpy(<[s1]>, <[s2]>, <[n]>
++	wchar_t *<[s1]>;
++	const wchar_t *<[s2]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wcsncpy>> function copies not more than <[n]> wide-character codes
++	(wide-character codes that follow a null wide-character code are not
++	copied) from the array pointed to by <[s2]> to the array pointed to
++	by <[s1]>. If copying takes place between objects that overlap, the
++	behaviour is undefined.  Note that if <[s1]> contains more than <[n]>
++	wide characters before its terminating null, the result is not
++	null-terminated.
++
++	If the array pointed to by <[s2]> is a wide-character string that is
++	shorter than <[n]> wide-character codes, null wide-character codes are
++	appended to the copy in the array pointed to by <[s1]>, until <[n]>
++	wide-character codes in all are written. 
++
++RETURNS
++	The <<wcsncpy>> function returns <[s1]>; no return value is reserved to
++	indicate an error. 
++
++PORTABILITY
++ISO/IEC 9899; POSIX.1.
++
++No supporting OS subroutines are required.
++*/
++
++#include <_ansi.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wcsncpy, (s1, s2, n),
++	wchar_t * s1 _AND
++	_CONST wchar_t * s2 _AND
++	size_t n)
++{
++  wchar_t *dscan=s1;
++
++  while(n > 0)
++    {
++      --n;
++      if((*dscan++ = *s2++) == L'\0')  break;
++    }
++  while(n-- > 0)  *dscan++ = L'\0';
++
++  return s1;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcsrchr.c b/msys/rt/src/newlib/libc/string/wcsrchr.c
+new file mode 100644
+index 0000000..495d95a
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcsrchr.c
+@@ -0,0 +1,88 @@
++/*
++FUNCTION
++	<<wcsrchr>>---wide-character string scanning operation 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcsrchr(const wchar_t *<[s]>, wchar_t <[c]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wcsrchr(<[s]>, <[c]>
++	const wchar_t *<[s]>;
++	wchar_t <[c]>;
++
++DESCRIPTION
++	The <<wcsrchr>> function locates the last occurrence of <[c]> in the
++	wide-character string pointed to by <[s]>. The value of <[c]> must be a
++	character representable as a type wchar_t and must be a wide-character
++	code corresponding to a valid character in the current locale.
++	The terminating null wide-character code is considered to be part of
++	the wide-character string. 
++
++RETURNS
++	Upon successful completion, <<wcsrchr>> returns a pointer to the
++	wide-character code or a null pointer if <[c]> does not occur in the
++	wide-character string.
++
++PORTABILITY
++<<wcsrchr>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wcsrchr.c,v 1.1 2000/12/23 23:14:37 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wcsrchr.c,v 1.2 2000/12/21 05:07:25 itojun Exp
++ */
++
++#include <_ansi.h>
++#include <stddef.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wcsrchr, (s, c),
++	_CONST wchar_t * s _AND
++	wchar_t c)
++{
++  _CONST wchar_t *p;
++
++  p = s;
++  while (*p)
++    p++;
++  while (s <= p)
++    {
++      if (*p == c)
++	{
++	  /* LINTED interface specification */
++	  return (wchar_t *) p;
++	}
++      p--;
++    }
++  return NULL;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcswidth.c b/msys/rt/src/newlib/libc/string/wcswidth.c
+new file mode 100644
+index 0000000..6c0efe6
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcswidth.c
+@@ -0,0 +1,73 @@
++/*
++FUNCTION
++	<<wcswidth>>---number of column positions of a wide-character string
++	
++INDEX
++	wcswidth
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wcswidth(const wchar_t *<[pwcs]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	int wcswidth(<[pwcs]>, <[n]>)
++	wchar_t *<[wc]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wcswidth>> function shall determine the number of column
++	positions required for <[n]> wide-character codes (or fewer than <[n]>
++	wide-character codes if a null wide-character code is encountered
++	before <[n]> wide-character codes are exhausted) in the string pointed
++	to by <[pwcs]>.
++
++RETURNS
++	The <<wcswidth>> function either shall return 0 (if <[pwcs]> points to a
++	null wide-character code), or return the number of column positions
++	to be occupied by the wide-character string pointed to by <[pwcs]>, or
++	return -1 (if any of the first <[n]> wide-character codes in the
++	wide-character string pointed to by <[pwcs]> is not a printable
++	wide-character code).
++
++PORTABILITY
++<<wcswidth>> has been introduced in the Single UNIX Specification Volume 2.
++<<wcswidth>> has been marked as an extension in the Single UNIX Specification Volume 3.
++*/
++
++#include <_ansi.h>
++#include <wchar.h>
++#include "local.h"
++
++int
++_DEFUN (wcswidth, (pwcs, n),
++	_CONST wchar_t *pwcs _AND
++	size_t n)
++
++{
++  int w, len = 0;
++  if (!pwcs || n == 0)
++    return 0;
++  do {
++    wint_t wi = *pwcs;
++
++#ifdef _MB_CAPABLE
++  wi = _jp2uc (wi);
++  /* First half of a surrogate pair? */
++  if (sizeof (wchar_t) == 2 && wi >= 0xd800 && wi <= 0xdbff)
++    {
++      wint_t wi2;
++
++      /* Extract second half and check for validity. */
++      if (--n == 0 || (wi2 = _jp2uc (*++pwcs)) < 0xdc00 || wi2 > 0xdfff)
++	return -1;
++      /* Compute actual unicode value to use in call to __wcwidth. */
++      wi = (((wi & 0x3ff) << 10) | (wi2 & 0x3ff)) + 0x10000;
++    }
++#endif /* _MB_CAPABLE */
++    if ((w = __wcwidth (wi)) < 0)
++      return -1;
++    len += w;
++  } while (*pwcs++ && --n > 0);
++  return len;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wcwidth.c b/msys/rt/src/newlib/libc/string/wcwidth.c
+new file mode 100644
+index 0000000..ac5c47f
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wcwidth.c
+@@ -0,0 +1,346 @@
++/*
++FUNCTION
++	<<wcwidth>>---number of column positions of a wide-character code
++	
++INDEX
++	wcwidth
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wcwidth(const wchar_t <[wc]>);
++
++TRAD_SYNOPSIS
++	#include <wchar.h>
++	int wcwidth(<[wc]>)
++	wchar_t *<[wc]>;
++
++DESCRIPTION
++	The <<wcwidth>> function shall determine the number of column
++	positions required for the wide character <[wc]>. The application
++	shall ensure that the value of <[wc]> is a character representable
++	as a wchar_t, and is a wide-character code corresponding to a
++	valid character in the current locale.
++
++RETURNS
++	The <<wcwidth>> function shall either return 0 (if <[wc]> is a null
++	wide-character code), or return the number of column positions to
++	be occupied by the wide-character code <[wc]>, or return -1 (if <[wc]>
++	does not correspond to a printable wide-character code).
++
++PORTABILITY
++<<wcwidth>> has been introduced in the Single UNIX Specification Volume 2.
++<<wcwidth>> has been marked as an extension in the Single UNIX Specification Volume 3.
++*/
++
++/*
++ * This is an implementation of wcwidth() (defined in
++ * IEEE Std 1002.1-2001) for Unicode.
++ *
++ * http://www.opengroup.org/onlinepubs/007904975/functions/wcwidth.html
++ *
++ * In fixed-width output devices, Latin characters all occupy a single
++ * "cell" position of equal width, whereas ideographic CJK characters
++ * occupy two such cells. Interoperability between terminal-line
++ * applications and (teletype-style) character terminals using the
++ * UTF-8 encoding requires agreement on which character should advance
++ * the cursor by how many cell positions. No established formal
++ * standards exist at present on which Unicode character shall occupy
++ * how many cell positions on character terminals. These routines are
++ * a first attempt of defining such behavior based on simple rules
++ * applied to data provided by the Unicode Consortium.
++ *
++ * For some graphical characters, the Unicode standard explicitly
++ * defines a character-cell width via the definition of the East Asian
++ * FullWidth (F), Wide (W), Half-width (H), and Narrow (Na) classes.
++ * In all these cases, there is no ambiguity about which width a
++ * terminal shall use. For characters in the East Asian Ambiguous (A)
++ * class, the width choice depends purely on a preference of backward
++ * compatibility with either historic CJK or Western practice.
++ * Choosing single-width for these characters is easy to justify as
++ * the appropriate long-term solution, as the CJK practice of
++ * displaying these characters as double-width comes from historic
++ * implementation simplicity (8-bit encoded characters were displayed
++ * single-width and 16-bit ones double-width, even for Greek,
++ * Cyrillic, etc.) and not any typographic considerations.
++ *
++ * Much less clear is the choice of width for the Not East Asian
++ * (Neutral) class. Existing practice does not dictate a width for any
++ * of these characters. It would nevertheless make sense
++ * typographically to allocate two character cells to characters such
++ * as for instance EM SPACE or VOLUME INTEGRAL, which cannot be
++ * represented adequately with a single-width glyph. The following
++ * routines at present merely assign a single-cell width to all
++ * neutral characters, in the interest of simplicity. This is not
++ * entirely satisfactory and should be reconsidered before
++ * establishing a formal standard in this area. At the moment, the
++ * decision which Not East Asian (Neutral) characters should be
++ * represented by double-width glyphs cannot yet be answered by
++ * applying a simple rule from the Unicode database content. Setting
++ * up a proper standard for the behavior of UTF-8 character terminals
++ * will require a careful analysis not only of each Unicode character,
++ * but also of each presentation form, something the author of these
++ * routines has avoided to do so far.
++ *
++ * http://www.unicode.org/unicode/reports/tr11/
++ *
++ * Markus Kuhn -- 2007-05-26 (Unicode 5.0)
++ *
++ * Permission to use, copy, modify, and distribute this software
++ * for any purpose and without fee is hereby granted. The author
++ * disclaims all warranties with regard to this software.
++ *
++ * Latest version: http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++#ifndef _MB_CAPABLE
++#include <wctype.h> /* iswprint, iswcntrl */
++#endif
++#include "local.h"
++
++#ifdef _MB_CAPABLE
++struct interval
++{
++  int first;
++  int last;
++};
++
++/* auxiliary function for binary search in interval table */
++static int
++bisearch(wint_t ucs, const struct interval *table, int max)
++{
++  int min = 0;
++  int mid;
++
++  if (ucs < table[0].first || ucs > table[max].last)
++    return 0;
++  while (max >= min)
++    {
++      mid = (min + max) / 2;
++      if (ucs > table[mid].last)
++	min = mid + 1;
++      else if (ucs < table[mid].first)
++	max = mid - 1;
++      else
++	return 1;
++    }
++
++  return 0;
++}
++#endif /* _MB_CAPABLE */
++
++/* The following function defines the column width of an ISO 10646
++ * character as follows:
++ *
++ *    - The null character (U+0000) has a column width of 0.
++ *
++ *    - Other C0/C1 control characters and DEL will lead to a return
++ *      value of -1.
++ *
++ *    - If the current language is recognized as a language usually using
++ *      CJK fonts, spacing characters in the East Asian Ambiguous (A)
++ *      category as defined in Unicode Technical Report #11 have a column
++ *      width of 2.
++ *
++ *    - Non-spacing and enclosing combining characters (general
++ *      category code Mn or Me in the Unicode database) have a
++ *      column width of 0.
++ *
++ *    - SOFT HYPHEN (U+00AD) has a column width of 1.
++ *
++ *    - Other format characters (general category code Cf in the Unicode
++ *      database) and ZERO WIDTH SPACE (U+200B) have a column width of 0.
++ *
++ *    - Hangul Jamo medial vowels and final consonants (U+1160-U+11FF)
++ *      have a column width of 0.
++ *
++ *    - Spacing characters in the East Asian Wide (W) or East Asian
++ *      Full-width (F) category as defined in Unicode Technical
++ *      Report #11 have a column width of 2.
++ *
++ *    - All remaining characters (including all printable
++ *      ISO 8859-1 and WGL4 characters, Unicode control characters,
++ *      etc.) have a column width of 1.
++ *
++ * This implementation assumes that wint_t characters are encoded
++ * in ISO 10646.
++ */
++
++int
++_DEFUN (__wcwidth, (ucs),
++	_CONST wint_t ucs)
++{
++#ifdef _MB_CAPABLE
++  /* sorted list of non-overlapping intervals of East Asian Ambiguous
++   * characters, generated by "uniset +WIDTH-A -cat=Me -cat=Mn -cat=Cf c" */
++  static const struct interval ambiguous[] = {
++    { 0x00A1, 0x00A1 }, { 0x00A4, 0x00A4 }, { 0x00A7, 0x00A8 },
++    { 0x00AA, 0x00AA }, { 0x00AE, 0x00AE }, { 0x00B0, 0x00B4 },
++    { 0x00B6, 0x00BA }, { 0x00BC, 0x00BF }, { 0x00C6, 0x00C6 },
++    { 0x00D0, 0x00D0 }, { 0x00D7, 0x00D8 }, { 0x00DE, 0x00E1 },
++    { 0x00E6, 0x00E6 }, { 0x00E8, 0x00EA }, { 0x00EC, 0x00ED },
++    { 0x00F0, 0x00F0 }, { 0x00F2, 0x00F3 }, { 0x00F7, 0x00FA },
++    { 0x00FC, 0x00FC }, { 0x00FE, 0x00FE }, { 0x0101, 0x0101 },
++    { 0x0111, 0x0111 }, { 0x0113, 0x0113 }, { 0x011B, 0x011B },
++    { 0x0126, 0x0127 }, { 0x012B, 0x012B }, { 0x0131, 0x0133 },
++    { 0x0138, 0x0138 }, { 0x013F, 0x0142 }, { 0x0144, 0x0144 },
++    { 0x0148, 0x014B }, { 0x014D, 0x014D }, { 0x0152, 0x0153 },
++    { 0x0166, 0x0167 }, { 0x016B, 0x016B }, { 0x01CE, 0x01CE },
++    { 0x01D0, 0x01D0 }, { 0x01D2, 0x01D2 }, { 0x01D4, 0x01D4 },
++    { 0x01D6, 0x01D6 }, { 0x01D8, 0x01D8 }, { 0x01DA, 0x01DA },
++    { 0x01DC, 0x01DC }, { 0x0251, 0x0251 }, { 0x0261, 0x0261 },
++    { 0x02C4, 0x02C4 }, { 0x02C7, 0x02C7 }, { 0x02C9, 0x02CB },
++    { 0x02CD, 0x02CD }, { 0x02D0, 0x02D0 }, { 0x02D8, 0x02DB },
++    { 0x02DD, 0x02DD }, { 0x02DF, 0x02DF }, { 0x0391, 0x03A1 },
++    { 0x03A3, 0x03A9 }, { 0x03B1, 0x03C1 }, { 0x03C3, 0x03C9 },
++    { 0x0401, 0x0401 }, { 0x0410, 0x044F }, { 0x0451, 0x0451 },
++    { 0x2010, 0x2010 }, { 0x2013, 0x2016 }, { 0x2018, 0x2019 },
++    { 0x201C, 0x201D }, { 0x2020, 0x2022 }, { 0x2024, 0x2027 },
++    { 0x2030, 0x2030 }, { 0x2032, 0x2033 }, { 0x2035, 0x2035 },
++    { 0x203B, 0x203B }, { 0x203E, 0x203E }, { 0x2074, 0x2074 },
++    { 0x207F, 0x207F }, { 0x2081, 0x2084 }, { 0x20AC, 0x20AC },
++    { 0x2103, 0x2103 }, { 0x2105, 0x2105 }, { 0x2109, 0x2109 },
++    { 0x2113, 0x2113 }, { 0x2116, 0x2116 }, { 0x2121, 0x2122 },
++    { 0x2126, 0x2126 }, { 0x212B, 0x212B }, { 0x2153, 0x2154 },
++    { 0x215B, 0x215E }, { 0x2160, 0x216B }, { 0x2170, 0x2179 },
++    { 0x2190, 0x2199 }, { 0x21B8, 0x21B9 }, { 0x21D2, 0x21D2 },
++    { 0x21D4, 0x21D4 }, { 0x21E7, 0x21E7 }, { 0x2200, 0x2200 },
++    { 0x2202, 0x2203 }, { 0x2207, 0x2208 }, { 0x220B, 0x220B },
++    { 0x220F, 0x220F }, { 0x2211, 0x2211 }, { 0x2215, 0x2215 },
++    { 0x221A, 0x221A }, { 0x221D, 0x2220 }, { 0x2223, 0x2223 },
++    { 0x2225, 0x2225 }, { 0x2227, 0x222C }, { 0x222E, 0x222E },
++    { 0x2234, 0x2237 }, { 0x223C, 0x223D }, { 0x2248, 0x2248 },
++    { 0x224C, 0x224C }, { 0x2252, 0x2252 }, { 0x2260, 0x2261 },
++    { 0x2264, 0x2267 }, { 0x226A, 0x226B }, { 0x226E, 0x226F },
++    { 0x2282, 0x2283 }, { 0x2286, 0x2287 }, { 0x2295, 0x2295 },
++    { 0x2299, 0x2299 }, { 0x22A5, 0x22A5 }, { 0x22BF, 0x22BF },
++    { 0x2312, 0x2312 }, { 0x2460, 0x24E9 }, { 0x24EB, 0x254B },
++    { 0x2550, 0x2573 }, { 0x2580, 0x258F }, { 0x2592, 0x2595 },
++    { 0x25A0, 0x25A1 }, { 0x25A3, 0x25A9 }, { 0x25B2, 0x25B3 },
++    { 0x25B6, 0x25B7 }, { 0x25BC, 0x25BD }, { 0x25C0, 0x25C1 },
++    { 0x25C6, 0x25C8 }, { 0x25CB, 0x25CB }, { 0x25CE, 0x25D1 },
++    { 0x25E2, 0x25E5 }, { 0x25EF, 0x25EF }, { 0x2605, 0x2606 },
++    { 0x2609, 0x2609 }, { 0x260E, 0x260F }, { 0x2614, 0x2615 },
++    { 0x261C, 0x261C }, { 0x261E, 0x261E }, { 0x2640, 0x2640 },
++    { 0x2642, 0x2642 }, { 0x2660, 0x2661 }, { 0x2663, 0x2665 },
++    { 0x2667, 0x266A }, { 0x266C, 0x266D }, { 0x266F, 0x266F },
++    { 0x273D, 0x273D }, { 0x2776, 0x277F }, { 0xE000, 0xF8FF },
++    { 0xFFFD, 0xFFFD }, { 0xF0000, 0xFFFFD }, { 0x100000, 0x10FFFD }
++  };
++  /* sorted list of non-overlapping intervals of non-spacing characters */
++  /* generated by "uniset +cat=Me +cat=Mn +cat=Cf -00AD +1160-11FF +200B c" */
++  static const struct interval combining[] = {
++    { 0x0300, 0x036F }, { 0x0483, 0x0486 }, { 0x0488, 0x0489 },
++    { 0x0591, 0x05BD }, { 0x05BF, 0x05BF }, { 0x05C1, 0x05C2 },
++    { 0x05C4, 0x05C5 }, { 0x05C7, 0x05C7 }, { 0x0600, 0x0603 },
++    { 0x0610, 0x0615 }, { 0x064B, 0x065E }, { 0x0670, 0x0670 },
++    { 0x06D6, 0x06E4 }, { 0x06E7, 0x06E8 }, { 0x06EA, 0x06ED },
++    { 0x070F, 0x070F }, { 0x0711, 0x0711 }, { 0x0730, 0x074A },
++    { 0x07A6, 0x07B0 }, { 0x07EB, 0x07F3 }, { 0x0901, 0x0902 },
++    { 0x093C, 0x093C }, { 0x0941, 0x0948 }, { 0x094D, 0x094D },
++    { 0x0951, 0x0954 }, { 0x0962, 0x0963 }, { 0x0981, 0x0981 },
++    { 0x09BC, 0x09BC }, { 0x09C1, 0x09C4 }, { 0x09CD, 0x09CD },
++    { 0x09E2, 0x09E3 }, { 0x0A01, 0x0A02 }, { 0x0A3C, 0x0A3C },
++    { 0x0A41, 0x0A42 }, { 0x0A47, 0x0A48 }, { 0x0A4B, 0x0A4D },
++    { 0x0A70, 0x0A71 }, { 0x0A81, 0x0A82 }, { 0x0ABC, 0x0ABC },
++    { 0x0AC1, 0x0AC5 }, { 0x0AC7, 0x0AC8 }, { 0x0ACD, 0x0ACD },
++    { 0x0AE2, 0x0AE3 }, { 0x0B01, 0x0B01 }, { 0x0B3C, 0x0B3C },
++    { 0x0B3F, 0x0B3F }, { 0x0B41, 0x0B43 }, { 0x0B4D, 0x0B4D },
++    { 0x0B56, 0x0B56 }, { 0x0B82, 0x0B82 }, { 0x0BC0, 0x0BC0 },
++    { 0x0BCD, 0x0BCD }, { 0x0C3E, 0x0C40 }, { 0x0C46, 0x0C48 },
++    { 0x0C4A, 0x0C4D }, { 0x0C55, 0x0C56 }, { 0x0CBC, 0x0CBC },
++    { 0x0CBF, 0x0CBF }, { 0x0CC6, 0x0CC6 }, { 0x0CCC, 0x0CCD },
++    { 0x0CE2, 0x0CE3 }, { 0x0D41, 0x0D43 }, { 0x0D4D, 0x0D4D },
++    { 0x0DCA, 0x0DCA }, { 0x0DD2, 0x0DD4 }, { 0x0DD6, 0x0DD6 },
++    { 0x0E31, 0x0E31 }, { 0x0E34, 0x0E3A }, { 0x0E47, 0x0E4E },
++    { 0x0EB1, 0x0EB1 }, { 0x0EB4, 0x0EB9 }, { 0x0EBB, 0x0EBC },
++    { 0x0EC8, 0x0ECD }, { 0x0F18, 0x0F19 }, { 0x0F35, 0x0F35 },
++    { 0x0F37, 0x0F37 }, { 0x0F39, 0x0F39 }, { 0x0F71, 0x0F7E },
++    { 0x0F80, 0x0F84 }, { 0x0F86, 0x0F87 }, { 0x0F90, 0x0F97 },
++    { 0x0F99, 0x0FBC }, { 0x0FC6, 0x0FC6 }, { 0x102D, 0x1030 },
++    { 0x1032, 0x1032 }, { 0x1036, 0x1037 }, { 0x1039, 0x1039 },
++    { 0x1058, 0x1059 }, { 0x1160, 0x11FF }, { 0x135F, 0x135F },
++    { 0x1712, 0x1714 }, { 0x1732, 0x1734 }, { 0x1752, 0x1753 },
++    { 0x1772, 0x1773 }, { 0x17B4, 0x17B5 }, { 0x17B7, 0x17BD },
++    { 0x17C6, 0x17C6 }, { 0x17C9, 0x17D3 }, { 0x17DD, 0x17DD },
++    { 0x180B, 0x180D }, { 0x18A9, 0x18A9 }, { 0x1920, 0x1922 },
++    { 0x1927, 0x1928 }, { 0x1932, 0x1932 }, { 0x1939, 0x193B },
++    { 0x1A17, 0x1A18 }, { 0x1B00, 0x1B03 }, { 0x1B34, 0x1B34 },
++    { 0x1B36, 0x1B3A }, { 0x1B3C, 0x1B3C }, { 0x1B42, 0x1B42 },
++    { 0x1B6B, 0x1B73 }, { 0x1DC0, 0x1DCA }, { 0x1DFE, 0x1DFF },
++    { 0x200B, 0x200F }, { 0x202A, 0x202E }, { 0x2060, 0x2063 },
++    { 0x206A, 0x206F }, { 0x20D0, 0x20EF }, { 0x302A, 0x302F },
++    { 0x3099, 0x309A }, { 0xA806, 0xA806 }, { 0xA80B, 0xA80B },
++    { 0xA825, 0xA826 }, { 0xFB1E, 0xFB1E }, { 0xFE00, 0xFE0F },
++    { 0xFE20, 0xFE23 }, { 0xFEFF, 0xFEFF }, { 0xFFF9, 0xFFFB },
++    { 0x10A01, 0x10A03 }, { 0x10A05, 0x10A06 }, { 0x10A0C, 0x10A0F },
++    { 0x10A38, 0x10A3A }, { 0x10A3F, 0x10A3F }, { 0x1D167, 0x1D169 },
++    { 0x1D173, 0x1D182 }, { 0x1D185, 0x1D18B }, { 0x1D1AA, 0x1D1AD },
++    { 0x1D242, 0x1D244 }, { 0xE0001, 0xE0001 }, { 0xE0020, 0xE007F },
++    { 0xE0100, 0xE01EF }
++  };
++
++  /* Test for NUL character */
++  if (ucs == 0)
++    return 0;
++
++  /* Test for printable ASCII characters */
++  if (ucs >= 0x20 && ucs < 0x7f)
++    return 1;
++
++  /* Test for control characters */
++  if (ucs < 0xa0)
++    return -1;
++
++  /* Test for surrogate pair values. */
++  if (ucs >= 0xd800 && ucs <= 0xdfff)
++    return -1;
++
++  /* binary search in table of ambiguous characters */
++  if (__locale_cjk_lang ()
++      && bisearch(ucs, ambiguous,
++		  sizeof(ambiguous) / sizeof(struct interval) - 1))
++    return 2;
++
++  /* binary search in table of non-spacing characters */
++  if (bisearch(ucs, combining,
++	       sizeof(combining) / sizeof(struct interval) - 1))
++    return 0;
++
++  /* if we arrive here, ucs is not a combining or C0/C1 control character */
++
++  return 1 + 
++    (ucs >= 0x1100 &&
++     (ucs <= 0x115f ||                    /* Hangul Jamo init. consonants */
++      ucs == 0x2329 || ucs == 0x232a ||
++      (ucs >= 0x2e80 && ucs <= 0xa4cf &&
++       ucs != 0x303f) ||                  /* CJK ... Yi */
++      (ucs >= 0xac00 && ucs <= 0xd7a3) || /* Hangul Syllables */
++      (ucs >= 0xf900 && ucs <= 0xfaff) || /* CJK Compatibility Ideographs */
++      (ucs >= 0xfe10 && ucs <= 0xfe19) || /* Vertical forms */
++      (ucs >= 0xfe30 && ucs <= 0xfe6f) || /* CJK Compatibility Forms */
++      (ucs >= 0xff00 && ucs <= 0xff60) || /* Fullwidth Forms */
++      (ucs >= 0xffe0 && ucs <= 0xffe6) ||
++      (ucs >= 0x20000 && ucs <= 0x2fffd) ||
++      (ucs >= 0x30000 && ucs <= 0x3fffd)));
++#else /* !_MB_CAPABLE */
++  if (iswprint (ucs))
++    return 1;
++  if (iswcntrl (ucs) || ucs == L'\0')
++    return 0;
++  return -1;
++#endif /* _MB_CAPABLE */
++}
++
++int     
++_DEFUN (wcwidth, (wc),
++	_CONST wchar_t wc)
++{ 
++  wint_t wi = wc;
++
++#ifdef _MB_CAPABLE
++  wi = _jp2uc (wi);
++#endif /* _MB_CAPABLE */
++  return __wcwidth (wi);
++}
+diff --git a/msys/rt/src/newlib/libc/string/wmemchr.c b/msys/rt/src/newlib/libc/string/wmemchr.c
+new file mode 100644
+index 0000000..b582b89
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wmemchr.c
+@@ -0,0 +1,89 @@
++/*
++FUNCTION
++	<<wmemchr>>---find a wide character in memory
++ 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t	*wmemchr(const wchar_t *<[s]>, wchar_t <[c]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	wchar_t	*wmemchr(<[s]>, <[c]>, <[n]>
++	const wchar_t *<[s]>;
++	wchar_t <[c]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wmemchr>> function locates the first occurrence of <[c]> in the
++	initial <[n]> wide characters of the object pointed to be <[s]>. This
++	function is not affected by locale and all wchar_t values are treated
++	identically.  The null wide character and wchar_t values not
++	corresponding to valid characters are not treated specially.
++
++	If <[n]> is zero, <[s]> must be a valid pointer and the function
++	behaves as if no valid occurrence of <[c]> is found. 
++
++RETURNS
++	The <<wmemchr>> function returns a pointer to the located
++	wide character, or a null pointer if the wide character does not occur
++	in the object. 
++
++PORTABILITY
++<<wmemchr>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wmemchr.c,v 1.1 2000/12/23 23:14:37 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wmemchr.c,v 1.2 2000/12/20 14:08:31 itojun Exp
++ */
++
++
++#include <_ansi.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wmemchr, (s, c, n),
++	_CONST wchar_t * s _AND
++	wchar_t c _AND
++	size_t n)
++{
++  size_t i;
++
++  for (i = 0; i < n; i++)
++    {
++      if (*s == c)
++	{
++	  /* LINTED const castaway */
++	  return (wchar_t *) s;
++	}
++      s++;
++    }
++  return NULL;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wmemcmp.c b/msys/rt/src/newlib/libc/string/wmemcmp.c
+new file mode 100644
+index 0000000..af9ee32
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wmemcmp.c
+@@ -0,0 +1,89 @@
++/*
++FUNCTION
++	<<wmemcmp>>---compare wide characters in memory 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	int wmemcmp(const wchar_t *<[s1]>, const wchar_t *<[s2]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	int wmemcmp(<[s1]>, <[s2]>, <[n]>
++	const wchar_t *<[s1]>;
++	const wchar_t *<[s2]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wmemcmp>> function compares the first <[n]> wide characters of the
++	object pointed to by <[s1]> to the first <[n]> wide characters of the
++	object pointed to by <[s2]>. This function is not affected by locale
++	and all wchar_t values are treated identically. The null wide character
++	and wchar_t values not corresponding to valid characters are not treated
++	specially.
++
++	If <[n]> is zero, <[s1]> and <[s2]> must be a valid pointers and the
++	function behaves as if the two objects compare equal. 
++
++RETURNS
++	The <<wmemcmp>> function returns an integer greater than, equal to,
++	or less than zero, accordingly as the object pointed to by <[s1]> is
++	greater than, equal to, or less than the object pointed to by <[s2]>.
++
++PORTABILITY
++<<wmemcmp>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wmemcmp.c,v 1.1 2000/12/23 23:14:37 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wmemcmp.c,v 1.2 2000/12/20 14:08:31 itojun Exp
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++int
++_DEFUN (wmemcmp, (s1, s2, n),
++	_CONST wchar_t * s1 _AND
++	_CONST wchar_t * s2 _AND
++	size_t n)
++{
++  size_t i;
++
++  for (i = 0; i < n; i++)
++    {
++      if (*s1 != *s2)
++	{
++	  /* wchar might be unsigned */
++	  return *s1 > *s2 ? 1 : -1;
++	}
++      s1++;
++      s2++;
++    }
++  return 0;
++}
+diff --git a/msys/rt/src/newlib/libc/string/wmemcpy.c b/msys/rt/src/newlib/libc/string/wmemcpy.c
+new file mode 100644
+index 0000000..748e8e1
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wmemcpy.c
+@@ -0,0 +1,76 @@
++/*
++FUNCTION
++	<<wmemcpy>>---copy wide characters in memory 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wmemcpy(wchar_t *<[d]>, const wchar_t *<[s]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	wchar_t *wmemcpy(<[d]>, <[s]>, <[n]>
++	wchar_t *<[d]>;
++	const wchar_t *<[s]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wmemcpy>> function copies <[n]> wide characters from the object
++	pointed to by <[s]> to the object pointed to be <[d]>. This function
++	is not affected by locale and all wchar_t values are treated
++	identically.  The null wide character and wchar_t values not
++	corresponding to valid characters are not treated specially.
++
++	If <[n]> is zero, <[d]> and <[s]> must be a valid pointers, and the
++	function copies zero wide characters. 
++
++RETURNS
++	The <<wmemcpy>> function returns the value of <[d]>.
++
++PORTABILITY
++<<wmemcpy>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wmemcpy.c,v 1.1 2000/12/23 23:14:37 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wmemcpy.c,v 1.2 2000/12/20 14:08:31 itojun Exp
++ */
++
++#include <_ansi.h>
++#include <string.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wmemcpy, (d, s, n),
++	wchar_t * d _AND
++	_CONST wchar_t * s _AND
++	size_t n)
++{
++
++  return (wchar_t *) memcpy (d, s, n * sizeof (wchar_t));
++}
+diff --git a/msys/rt/src/newlib/libc/string/wmemmove.c b/msys/rt/src/newlib/libc/string/wmemmove.c
+new file mode 100644
+index 0000000..e20a26a
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wmemmove.c
+@@ -0,0 +1,82 @@
++/*
++FUNCTION
++	<<wmemmove>>---copy wide characters in memory with overlapping areas 
++
++ANSI_SYNOPSIS
++	#include <wchar.h>
++	wchar_t *wmemmove(wchar_t *<[d]>, const wchar_t *<[s]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++	wchar_t *wmemmove(<[d]>, <[s]>, <[n]>
++	wchar_t *<[d]>;
++	const wchar_t *<[s]>;
++	size_t <[n]>;
++
++DESCRIPTION
++	The <<wmemmove>> function copies <[n]> wide characters from the object
++	pointed to by <[s]> to the object pointed to by <[d]>. Copying takes
++	place as if the <[n]> wide characters from the object pointed to by
++	<[s]> are first copied into a temporary array of <[n]> wide characters
++	that does not overlap the objects pointed to by <[d]> or <[s]>, and then
++	the <[n]> wide characters from the temporary array are copied into the
++	object pointed to by <[d]>.
++
++	This function is not affected by locale and all wchar_t values are
++	treated identically. The null wide character and wchar_t values not
++	corresponding to valid characters are not treated specially.
++
++	If <[n]> is zero, <[d]> and <[s]> must be a valid pointers, and the
++	function copies zero wide characters. 
++
++RETURNS
++	The <<wmemmove>> function returns the value of <[d]>.
++
++PORTABILITY
++<<wmemmove>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*	$NetBSD: wmemmove.c,v 1.1 2000/12/23 23:14:37 itojun Exp $	*/
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wmemmove.c,v 1.2 2000/12/20 14:08:31 itojun Exp
++ */
++
++#include <_ansi.h>
++#include <string.h>
++#include <wchar.h>
++
++wchar_t *
++_DEFUN (wmemmove, (d, s, n),
++	wchar_t * d _AND
++	_CONST wchar_t * s _AND
++	size_t n)
++{
++
++  return (wchar_t *) memmove (d, s, n * sizeof (wchar_t));
++}
+diff --git a/msys/rt/src/newlib/libc/string/wmemset.c b/msys/rt/src/newlib/libc/string/wmemset.c
+new file mode 100644
+index 0000000..0af6f91
+--- /dev/null
++++ b/msys/rt/src/newlib/libc/string/wmemset.c
+@@ -0,0 +1,82 @@
++/*
++FUNCTION
++       <<wmemset>>---set wide characters in memory 
++
++ANSI_SYNOPSIS
++       #include <wchar.h>
++       wchar_t *wmemset(wchar_t *<[s]>, wchar_t <[c]>, size_t <[n]>);
++
++TRAD_SYNOPSIS
++       wchar_t *wmemset(<[s]>, <[c]>, <[n]>
++       wchar_t *<[s]>;
++       wchar_t <[c]>;
++       size_t <[n]>;
++
++DESCRIPTION
++       The <<wmemset>> function copies the value of <[c]> into each of the
++       first <[n]> wide characters of the object pointed to by <[s]>.  This
++       function is not affected by locale and all wchar_t values are treated
++       identically.  The null wide character and wchar_t values not
++       corresponding to valid characters are not treated specially.
++
++       If <[n]> is zero, <[s]> must be a valid pointer and the function
++       copies zero wide characters.
++
++RETURNS
++       The <<wmemset>> function returns the value of <[s]>.
++
++PORTABILITY
++<<wmemset>> is ISO/IEC 9899/AMD1:1995 (ISO C).
++
++No supporting OS subroutines are required.
++*/
++
++/*     $NetBSD: wmemset.c,v 1.1 2000/12/23 23:14:37 itojun Exp $       */
++
++/*-
++ * Copyright (c)1999 Citrus Project,
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	citrus Id: wmemset.c,v 1.2 2000/12/20 14:08:31 itojun Exp
++ */
++
++#include <_ansi.h>
++#include <wchar.h>
++
++wchar_t	*
++_DEFUN(wmemset, (s, c, n),
++	wchar_t *s _AND
++	wchar_t c _AND
++	size_t n)
++{
++	size_t i;
++	wchar_t *p;
++
++	p = (wchar_t *)s;
++	for (i = 0; i < n; i++) {
++		*p = c;
++		p++;
++	}
++	return s;
++}
+diff --git a/msys/rt/src/winsup/cygwin/cygwin.din b/msys/rt/src/winsup/cygwin/cygwin.din
+index 4dbde75..7a8e419 100644
+--- a/msys/rt/src/winsup/cygwin/cygwin.din
++++ b/msys/rt/src/winsup/cygwin/cygwin.din
+@@ -1220,3 +1220,50 @@ AbsDllPath
+ _AbsDllPath=AbsDllPath
+ AbsExeModPath
+ _AbsExeModPath=AbsExeModPath
++mbrlen
++mbrtowc
++mbsinit
++mbsrtowcs
++mbsnrtowcs
++wctob
++wcrtomb
++wcsrtombs
++wcsnrtombs
++wcscasecmp
++wcschr
++wcscoll
++wcsdup
++wcsncasecmp
++wcsncmp
++wcsrchr
++wcwidth
++wcscat
++wcscmp
++wcscpy
++wcslen
++wcsncat
++wcsncpy
++wcswidth
++wmemchr
++wmemcmp
++wmemcpy
++wmemmove
++wmemset
++iswalnum
++iswblank
++iswctype
++iswgraph
++iswprint
++iswspace
++iswxdigit
++iswalpha
++iswcntrl
++iswdigit
++iswlower
++iswpunct
++iswupper
++towctrans
++towlower
++towupper
++wctrans
++wctype
+diff --git a/msys/rt/src/winsup/cygwin/include/limits.h b/msys/rt/src/winsup/cygwin/include/limits.h
+index 715a49a..67e9fd4 100644
+--- a/msys/rt/src/winsup/cygwin/include/limits.h
++++ b/msys/rt/src/winsup/cygwin/include/limits.h
+@@ -21,7 +21,7 @@ details. */
+ 
+ /* Maximum length of a multibyte character.  */
+ #ifndef MB_LEN_MAX
+-#define MB_LEN_MAX 1
++#define MB_LEN_MAX 8
+ #endif
+ 
+ /* Minimum and maximum values a `signed char' can hold.  */
+-- 
+1.7.10.rc1.5708.g87c2b
+

--- a/msys-core/0017-Fix-multibyte-compile-errors.patch
+++ b/msys-core/0017-Fix-multibyte-compile-errors.patch
@@ -1,0 +1,684 @@
+From c6acb9b09e647b82ce630b5d8065faa84fc5a049 Mon Sep 17 00:00:00 2001
+From: Doug Kelly <dougk.ff7@gmail.com>
+Date: Thu, 19 Jun 2014 10:35:44 -0500
+Subject: [PATCH 1/2] Fix multibyte compile errors
+
+_read_r and _write_r are defined with the wrong return type compared
+to their headers, which causes two different compile errors. This was
+caused by a mis-define in _types, which leaks out into cygwin...
+We'll fix it in both places for completeness.
+
+Also, winsup's include path takes precedence over newlib; to correct
+the wrong wchar.h getting included, explicitly include the relative
+path everywhere.  Obnoxious, but it does work.
+---
+ source/newlib/libc/include/sys/_types.h | 4 ----
+ source/newlib/libc/reent/readr.c        | 2 +-
+ source/newlib/libc/reent/writer.c       | 2 +-
+ source/newlib/libc/stdlib/local.h       | 4 ++--
+ source/newlib/libc/stdlib/mblen.c       | 2 +-
+ source/newlib/libc/stdlib/mblen_r.c     | 2 +-
+ source/newlib/libc/stdlib/mbrlen.c      | 2 +-
+ source/newlib/libc/stdlib/mbrtowc.c     | 2 +-
+ source/newlib/libc/stdlib/mbsinit.c     | 2 +-
+ source/newlib/libc/stdlib/mbsnrtowcs.c  | 2 +-
+ source/newlib/libc/stdlib/mbsrtowcs.c   | 2 +-
+ source/newlib/libc/stdlib/mbstowcs.c    | 2 +-
+ source/newlib/libc/stdlib/mbstowcs_r.c  | 2 +-
+ source/newlib/libc/stdlib/mbtowc.c      | 2 +-
+ source/newlib/libc/stdlib/mbtowc_r.c    | 2 +-
+ source/newlib/libc/stdlib/wcrtomb.c     | 2 +-
+ source/newlib/libc/stdlib/wcsnrtombs.c  | 2 +-
+ source/newlib/libc/stdlib/wcsrtombs.c   | 2 +-
+ source/newlib/libc/stdlib/wcstod.c      | 2 +-
+ source/newlib/libc/stdlib/wcstol.c      | 2 +-
+ source/newlib/libc/stdlib/wcstoll.c     | 2 +-
+ source/newlib/libc/stdlib/wcstoll_r.c   | 2 +-
+ source/newlib/libc/stdlib/wcstombs.c    | 2 +-
+ source/newlib/libc/stdlib/wcstombs_r.c  | 2 +-
+ source/newlib/libc/stdlib/wcstoul.c     | 2 +-
+ source/newlib/libc/stdlib/wcstoull.c    | 2 +-
+ source/newlib/libc/stdlib/wcstoull_r.c  | 2 +-
+ source/newlib/libc/stdlib/wctob.c       | 2 +-
+ source/newlib/libc/stdlib/wctomb_r.c    | 2 +-
+ source/newlib/libc/string/wcscasecmp.c  | 2 +-
+ source/newlib/libc/string/wcscat.c      | 2 +-
+ source/newlib/libc/string/wcschr.c      | 2 +-
+ source/newlib/libc/string/wcscoll.c     | 2 +-
+ source/newlib/libc/string/wcscpy.c      | 2 +-
+ source/newlib/libc/string/wcsdup.c      | 2 +-
+ source/newlib/libc/string/wcslen.c      | 2 +-
+ source/newlib/libc/string/wcsncasecmp.c | 2 +-
+ source/newlib/libc/string/wcsncat.c     | 2 +-
+ source/newlib/libc/string/wcsncmp.c     | 2 +-
+ source/newlib/libc/string/wcsncpy.c     | 2 +-
+ source/newlib/libc/string/wcsrchr.c     | 2 +-
+ source/newlib/libc/string/wcswidth.c    | 2 +-
+ source/newlib/libc/string/wcwidth.c     | 2 +-
+ source/newlib/libc/string/wmemchr.c     | 2 +-
+ source/newlib/libc/string/wmemcmp.c     | 2 +-
+ source/newlib/libc/string/wmemcpy.c     | 2 +-
+ source/newlib/libc/string/wmemmove.c    | 2 +-
+ source/newlib/libc/string/wmemset.c     | 2 +-
+ 48 files changed, 48 insertions(+), 52 deletions(-)
+
+diff --git a/source/newlib/libc/include/sys/_types.h b/source/newlib/libc/include/sys/_types.h
+index 11d02a1..9b4402c 100644
+--- a/source/newlib/libc/include/sys/_types.h
++++ b/source/newlib/libc/include/sys/_types.h
+@@ -34,12 +34,8 @@ __extension__ typedef long long _off64_t;
+ #endif
+ 
+ #ifndef __ssize_t_defined
+-#if defined(__INT_MAX__) && __INT_MAX__ == 2147483647
+-typedef int _ssize_t;
+-#else
+ typedef long _ssize_t;
+ #endif
+-#endif
+ 
+ #define __need_wint_t
+ #include <stddef.h>
+diff --git a/source/newlib/libc/reent/readr.c b/source/newlib/libc/reent/readr.c
+index e3deca9..7c4bf74 100644
+--- a/source/newlib/libc/reent/readr.c
++++ b/source/newlib/libc/reent/readr.c
+@@ -45,7 +45,7 @@ DESCRIPTION
+ 	<<errno>>.
+ */
+ 
+-long
++_ssize_t
+ _read_r (ptr, fd, buf, cnt)
+      struct _reent *ptr;
+      int fd;
+diff --git a/source/newlib/libc/reent/writer.c b/source/newlib/libc/reent/writer.c
+index ac10286..426df0d 100644
+--- a/source/newlib/libc/reent/writer.c
++++ b/source/newlib/libc/reent/writer.c
+@@ -45,7 +45,7 @@ DESCRIPTION
+ 	<<errno>>.
+ */
+ 
+-long
++_ssize_t
+ _write_r (ptr, fd, buf, cnt)
+      struct _reent *ptr;
+      int fd;
+diff --git a/source/newlib/libc/stdlib/local.h b/source/newlib/libc/stdlib/local.h
+index 4cfc128..f9fe47d 100644
+--- a/source/newlib/libc/stdlib/local.h
++++ b/source/newlib/libc/stdlib/local.h
+@@ -7,8 +7,8 @@ char *	_EXFUN(_gcvt,(struct _reent *, double , int , char *, char, int));
+ 
+ char *__locale_charset(_NOARGS);
+ 
+-#ifndef __mbstate_t_defined
+-#include <wchar.h>
++#ifndef _MBSTATE_T
++#include "../include/wchar.h"
+ #endif
+ 
+ extern int (*__wctomb) (struct _reent *, char *, wchar_t, const char *,
+diff --git a/source/newlib/libc/stdlib/mblen.c b/source/newlib/libc/stdlib/mblen.c
+index ace2388..a185e0f 100644
+--- a/source/newlib/libc/stdlib/mblen.c
++++ b/source/newlib/libc/stdlib/mblen.c
+@@ -45,7 +45,7 @@ effects vary with the locale.
+ 
+ #include <newlib.h>
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include "local.h"
+ 
+ int
+diff --git a/source/newlib/libc/stdlib/mblen_r.c b/source/newlib/libc/stdlib/mblen_r.c
+index c3b5964..af72a5b 100644
+--- a/source/newlib/libc/stdlib/mblen_r.c
++++ b/source/newlib/libc/stdlib/mblen_r.c
+@@ -45,7 +45,7 @@ effects vary with the locale.
+ 
+ #include <newlib.h>
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include "local.h"
+ 
+ int
+diff --git a/source/newlib/libc/stdlib/mbrlen.c b/source/newlib/libc/stdlib/mbrlen.c
+index ac9aa32..f2911e5 100644
+--- a/source/newlib/libc/stdlib/mbrlen.c
++++ b/source/newlib/libc/stdlib/mbrlen.c
+@@ -1,6 +1,6 @@
+ #include <reent.h>
+ #include <newlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/source/newlib/libc/stdlib/mbrtowc.c b/source/newlib/libc/stdlib/mbrtowc.c
+index e191e11..6d8acb7 100644
+--- a/source/newlib/libc/stdlib/mbrtowc.c
++++ b/source/newlib/libc/stdlib/mbrtowc.c
+@@ -1,6 +1,6 @@
+ #include <reent.h>
+ #include <newlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/source/newlib/libc/stdlib/mbsinit.c b/source/newlib/libc/stdlib/mbsinit.c
+index e32369a..b5ed637 100644
+--- a/source/newlib/libc/stdlib/mbsinit.c
++++ b/source/newlib/libc/stdlib/mbsinit.c
+@@ -1,5 +1,5 @@
+ #include <reent.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/source/newlib/libc/stdlib/mbsnrtowcs.c b/source/newlib/libc/stdlib/mbsnrtowcs.c
+index 6729df9..558ab4d 100644
+--- a/source/newlib/libc/stdlib/mbsnrtowcs.c
++++ b/source/newlib/libc/stdlib/mbsnrtowcs.c
+@@ -95,7 +95,7 @@ PORTABILITY
+ 
+ #include <reent.h>
+ #include <newlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/source/newlib/libc/stdlib/mbsrtowcs.c b/source/newlib/libc/stdlib/mbsrtowcs.c
+index d5137d1..84d7cf0 100644
+--- a/source/newlib/libc/stdlib/mbsrtowcs.c
++++ b/source/newlib/libc/stdlib/mbsrtowcs.c
+@@ -1,6 +1,6 @@
+ #include <reent.h>
+ #include <newlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/source/newlib/libc/stdlib/mbstowcs.c b/source/newlib/libc/stdlib/mbstowcs.c
+index 334b5f5..742d11e 100644
+--- a/source/newlib/libc/stdlib/mbstowcs.c
++++ b/source/newlib/libc/stdlib/mbstowcs.c
+@@ -51,7 +51,7 @@ effects vary with the locale.
+ 
+ #include <newlib.h>
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ size_t
+ _DEFUN (mbstowcs, (pwcs, s, n),
+diff --git a/source/newlib/libc/stdlib/mbstowcs_r.c b/source/newlib/libc/stdlib/mbstowcs_r.c
+index 3ba8677..8c8b7b3 100644
+--- a/source/newlib/libc/stdlib/mbstowcs_r.c
++++ b/source/newlib/libc/stdlib/mbstowcs_r.c
+@@ -1,5 +1,5 @@
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include "local.h"
+ 
+ size_t
+diff --git a/source/newlib/libc/stdlib/mbtowc.c b/source/newlib/libc/stdlib/mbtowc.c
+index 83b6a0e..eb43e86 100644
+--- a/source/newlib/libc/stdlib/mbtowc.c
++++ b/source/newlib/libc/stdlib/mbtowc.c
+@@ -53,7 +53,7 @@ effects vary with the locale.
+ 
+ #include <newlib.h>
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include "local.h"
+ 
+ int
+diff --git a/source/newlib/libc/stdlib/mbtowc_r.c b/source/newlib/libc/stdlib/mbtowc_r.c
+index 9e81a10..e240dd5 100644
+--- a/source/newlib/libc/stdlib/mbtowc_r.c
++++ b/source/newlib/libc/stdlib/mbtowc_r.c
+@@ -2,7 +2,7 @@
+ #include <stdlib.h>
+ #include <locale.h>
+ #include "mbctype.h"
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <string.h>
+ #include <errno.h>
+ #include "local.h"
+diff --git a/source/newlib/libc/stdlib/wcrtomb.c b/source/newlib/libc/stdlib/wcrtomb.c
+index 60e0d89..b108577 100644
+--- a/source/newlib/libc/stdlib/wcrtomb.c
++++ b/source/newlib/libc/stdlib/wcrtomb.c
+@@ -1,6 +1,6 @@
+ #include <reent.h>
+ #include <newlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/source/newlib/libc/stdlib/wcsnrtombs.c b/source/newlib/libc/stdlib/wcsnrtombs.c
+index 5f885a4..2c70c9d 100644
+--- a/source/newlib/libc/stdlib/wcsnrtombs.c
++++ b/source/newlib/libc/stdlib/wcsnrtombs.c
+@@ -95,7 +95,7 @@ PORTABILITY
+ 
+ #include <reent.h>
+ #include <newlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+diff --git a/source/newlib/libc/stdlib/wcsrtombs.c b/source/newlib/libc/stdlib/wcsrtombs.c
+index ea6bd9d..2e5b72c 100644
+--- a/source/newlib/libc/stdlib/wcsrtombs.c
++++ b/source/newlib/libc/stdlib/wcsrtombs.c
+@@ -1,6 +1,6 @@
+ #include <reent.h>
+ #include <newlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ size_t
+ _DEFUN (_wcsrtombs_r, (r, dst, src, len, ps),
+diff --git a/source/newlib/libc/stdlib/wcstod.c b/source/newlib/libc/stdlib/wcstod.c
+index d80454c..956b4f7 100644
+--- a/source/newlib/libc/stdlib/wcstod.c
++++ b/source/newlib/libc/stdlib/wcstod.c
+@@ -117,7 +117,7 @@ Supporting OS subroutines required: <<close>>, <<fstat>>, <<isatty>>,
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <wctype.h>
+ #include <locale.h>
+ #include <math.h>
+diff --git a/source/newlib/libc/stdlib/wcstol.c b/source/newlib/libc/stdlib/wcstol.c
+index e23254d..7452515 100644
+--- a/source/newlib/libc/stdlib/wcstol.c
++++ b/source/newlib/libc/stdlib/wcstol.c
+@@ -121,7 +121,7 @@ No supporting OS subroutines are required.
+ #include <limits.h>
+ #include <wctype.h>
+ #include <errno.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <reent.h>
+ 
+ /*
+diff --git a/source/newlib/libc/stdlib/wcstoll.c b/source/newlib/libc/stdlib/wcstoll.c
+index 75eda9f..656ef53 100644
+--- a/source/newlib/libc/stdlib/wcstoll.c
++++ b/source/newlib/libc/stdlib/wcstoll.c
+@@ -121,7 +121,7 @@ No supporting OS subroutines are required.
+ #include <limits.h>
+ #include <wctype.h>
+ #include <errno.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <reent.h>
+ 
+ #ifndef _REENT_ONLY
+diff --git a/source/newlib/libc/stdlib/wcstoll_r.c b/source/newlib/libc/stdlib/wcstoll_r.c
+index d6baaca..c6292ef 100644
+--- a/source/newlib/libc/stdlib/wcstoll_r.c
++++ b/source/newlib/libc/stdlib/wcstoll_r.c
+@@ -46,7 +46,7 @@
+ #include <limits.h>
+ #include <wctype.h>
+ #include <errno.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <reent.h>
+ 
+ /*
+diff --git a/source/newlib/libc/stdlib/wcstombs.c b/source/newlib/libc/stdlib/wcstombs.c
+index d0ef26e..70130f6 100644
+--- a/source/newlib/libc/stdlib/wcstombs.c
++++ b/source/newlib/libc/stdlib/wcstombs.c
+@@ -52,7 +52,7 @@ effects vary with the locale.
+ 
+ #include <newlib.h>
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ size_t
+ _DEFUN (wcstombs, (s, pwcs, n),
+diff --git a/source/newlib/libc/stdlib/wcstombs_r.c b/source/newlib/libc/stdlib/wcstombs_r.c
+index e74502f..79a5c3f 100644
+--- a/source/newlib/libc/stdlib/wcstombs_r.c
++++ b/source/newlib/libc/stdlib/wcstombs_r.c
+@@ -1,5 +1,5 @@
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include "local.h"
+ 
+ size_t
+diff --git a/source/newlib/libc/stdlib/wcstoul.c b/source/newlib/libc/stdlib/wcstoul.c
+index 44dfca3..08d5cbf 100644
+--- a/source/newlib/libc/stdlib/wcstoul.c
++++ b/source/newlib/libc/stdlib/wcstoul.c
+@@ -121,7 +121,7 @@ PORTABILITY
+ #include <_ansi.h>
+ #include <limits.h>
+ #include <wctype.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <reent.h>
+diff --git a/source/newlib/libc/stdlib/wcstoull.c b/source/newlib/libc/stdlib/wcstoull.c
+index 76caadf..2695980 100644
+--- a/source/newlib/libc/stdlib/wcstoull.c
++++ b/source/newlib/libc/stdlib/wcstoull.c
+@@ -123,7 +123,7 @@ PORTABILITY
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <reent.h>
+ 
+ #ifndef _REENT_ONLY
+diff --git a/source/newlib/libc/stdlib/wcstoull_r.c b/source/newlib/libc/stdlib/wcstoull_r.c
+index abad681..e174534 100644
+--- a/source/newlib/libc/stdlib/wcstoull_r.c
++++ b/source/newlib/libc/stdlib/wcstoull_r.c
+@@ -45,7 +45,7 @@
+ #define _GNU_SOURCE
+ #include <_ansi.h>
+ #include <limits.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <wctype.h>
+ #include <errno.h>
+ #include <reent.h>
+diff --git a/source/newlib/libc/stdlib/wctob.c b/source/newlib/libc/stdlib/wctob.c
+index d97c01f..f9b7a9e 100644
+--- a/source/newlib/libc/stdlib/wctob.c
++++ b/source/newlib/libc/stdlib/wctob.c
+@@ -1,5 +1,5 @@
+ #include <reent.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <stdio.h>
+ #include <string.h>
+ #include <limits.h>
+diff --git a/source/newlib/libc/stdlib/wctomb_r.c b/source/newlib/libc/stdlib/wctomb_r.c
+index 54d0106..187d1ab 100644
+--- a/source/newlib/libc/stdlib/wctomb_r.c
++++ b/source/newlib/libc/stdlib/wctomb_r.c
+@@ -1,7 +1,7 @@
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <locale.h>
+ #include "mbctype.h"
+ #include "local.h"
+diff --git a/source/newlib/libc/string/wcscasecmp.c b/source/newlib/libc/string/wcscasecmp.c
+index f9f169f..e9a30fa 100644
+--- a/source/newlib/libc/string/wcscasecmp.c
++++ b/source/newlib/libc/string/wcscasecmp.c
+@@ -38,7 +38,7 @@ QUICKREF
+ 	wcscasecmp 
+ */
+ 
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <wctype.h>
+ 
+ int
+diff --git a/source/newlib/libc/string/wcscat.c b/source/newlib/libc/string/wcscat.c
+index 54c0b50..779ff73 100644
+--- a/source/newlib/libc/string/wcscat.c
++++ b/source/newlib/libc/string/wcscat.c
+@@ -62,7 +62,7 @@ No supporting OS subroutines are required.
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wcscat, (s1, s2),
+diff --git a/source/newlib/libc/string/wcschr.c b/source/newlib/libc/string/wcschr.c
+index fb35d1f..d8d0011 100644
+--- a/source/newlib/libc/string/wcschr.c
++++ b/source/newlib/libc/string/wcschr.c
+@@ -60,7 +60,7 @@ No supporting OS subroutines are required.
+ 
+ #include <_ansi.h>
+ #include <stddef.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wcschr, (s, c),
+diff --git a/source/newlib/libc/string/wcscoll.c b/source/newlib/libc/string/wcscoll.c
+index 0f0513a..dda7dc3 100644
+--- a/source/newlib/libc/string/wcscoll.c
++++ b/source/newlib/libc/string/wcscoll.c
+@@ -36,7 +36,7 @@ PORTABILITY
+ */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ int
+ _DEFUN (wcscoll, (a, b),
+diff --git a/source/newlib/libc/string/wcscpy.c b/source/newlib/libc/string/wcscpy.c
+index ede693d..aef4365 100644
+--- a/source/newlib/libc/string/wcscpy.c
++++ b/source/newlib/libc/string/wcscpy.c
+@@ -58,7 +58,7 @@ No supporting OS subroutines are required.
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wcscpy, (s1, s2),
+diff --git a/source/newlib/libc/string/wcsdup.c b/source/newlib/libc/string/wcsdup.c
+index 90be68e..fd6dd53 100644
+--- a/source/newlib/libc/string/wcsdup.c
++++ b/source/newlib/libc/string/wcsdup.c
+@@ -39,7 +39,7 @@ QUICKREF
+ 
+ #include <reent.h>
+ #include <stdlib.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _wcsdup_r (struct _reent *p, const wchar_t *str)
+diff --git a/source/newlib/libc/string/wcslen.c b/source/newlib/libc/string/wcslen.c
+index d671551..d8a91e4 100644
+--- a/source/newlib/libc/string/wcslen.c
++++ b/source/newlib/libc/string/wcslen.c
+@@ -56,7 +56,7 @@ No supporting OS subroutines are required.
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ size_t
+ _DEFUN (wcslen, (s),
+diff --git a/source/newlib/libc/string/wcsncasecmp.c b/source/newlib/libc/string/wcsncasecmp.c
+index 1634ca1..01d3be8 100644
+--- a/source/newlib/libc/string/wcsncasecmp.c
++++ b/source/newlib/libc/string/wcsncasecmp.c
+@@ -40,7 +40,7 @@ QUICKREF
+ 	wcsncasecmp
+ */
+ 
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include <wctype.h>
+ 
+ int 
+diff --git a/source/newlib/libc/string/wcsncat.c b/source/newlib/libc/string/wcsncat.c
+index fd77c0c..ff9884a 100644
+--- a/source/newlib/libc/string/wcsncat.c
++++ b/source/newlib/libc/string/wcsncat.c
+@@ -64,7 +64,7 @@ No supporting OS subroutines are required.
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wcsncat, (s1, s2, n),
+diff --git a/source/newlib/libc/string/wcsncmp.c b/source/newlib/libc/string/wcsncmp.c
+index 1897f5c..9d750a8 100644
+--- a/source/newlib/libc/string/wcsncmp.c
++++ b/source/newlib/libc/string/wcsncmp.c
+@@ -66,7 +66,7 @@ No supporting OS subroutines are required.
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ int
+ _DEFUN (wcsncmp, (s1, s2, n),
+diff --git a/source/newlib/libc/string/wcsncpy.c b/source/newlib/libc/string/wcsncpy.c
+index 533b0ce..5a05070 100644
+--- a/source/newlib/libc/string/wcsncpy.c
++++ b/source/newlib/libc/string/wcsncpy.c
+@@ -37,7 +37,7 @@ No supporting OS subroutines are required.
+ */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wcsncpy, (s1, s2, n),
+diff --git a/source/newlib/libc/string/wcsrchr.c b/source/newlib/libc/string/wcsrchr.c
+index 495d95a..17d7315 100644
+--- a/source/newlib/libc/string/wcsrchr.c
++++ b/source/newlib/libc/string/wcsrchr.c
+@@ -63,7 +63,7 @@ No supporting OS subroutines are required.
+ 
+ #include <_ansi.h>
+ #include <stddef.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wcsrchr, (s, c),
+diff --git a/source/newlib/libc/string/wcswidth.c b/source/newlib/libc/string/wcswidth.c
+index 6c0efe6..17aeb8a 100644
+--- a/source/newlib/libc/string/wcswidth.c
++++ b/source/newlib/libc/string/wcswidth.c
+@@ -36,7 +36,7 @@ PORTABILITY
+ */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #include "local.h"
+ 
+ int
+diff --git a/source/newlib/libc/string/wcwidth.c b/source/newlib/libc/string/wcwidth.c
+index ac5c47f..f724e85 100644
+--- a/source/newlib/libc/string/wcwidth.c
++++ b/source/newlib/libc/string/wcwidth.c
+@@ -93,7 +93,7 @@ PORTABILITY
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ #ifndef _MB_CAPABLE
+ #include <wctype.h> /* iswprint, iswcntrl */
+ #endif
+diff --git a/source/newlib/libc/string/wmemchr.c b/source/newlib/libc/string/wmemchr.c
+index b582b89..b34a5ac 100644
+--- a/source/newlib/libc/string/wmemchr.c
++++ b/source/newlib/libc/string/wmemchr.c
+@@ -66,7 +66,7 @@ No supporting OS subroutines are required.
+ 
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wmemchr, (s, c, n),
+diff --git a/source/newlib/libc/string/wmemcmp.c b/source/newlib/libc/string/wmemcmp.c
+index af9ee32..7beceac 100644
+--- a/source/newlib/libc/string/wmemcmp.c
++++ b/source/newlib/libc/string/wmemcmp.c
+@@ -65,7 +65,7 @@ No supporting OS subroutines are required.
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ int
+ _DEFUN (wmemcmp, (s1, s2, n),
+diff --git a/source/newlib/libc/string/wmemcpy.c b/source/newlib/libc/string/wmemcpy.c
+index 748e8e1..037440e 100644
+--- a/source/newlib/libc/string/wmemcpy.c
++++ b/source/newlib/libc/string/wmemcpy.c
+@@ -63,7 +63,7 @@ No supporting OS subroutines are required.
+ 
+ #include <_ansi.h>
+ #include <string.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wmemcpy, (d, s, n),
+diff --git a/source/newlib/libc/string/wmemmove.c b/source/newlib/libc/string/wmemmove.c
+index e20a26a..d0c496d 100644
+--- a/source/newlib/libc/string/wmemmove.c
++++ b/source/newlib/libc/string/wmemmove.c
+@@ -69,7 +69,7 @@ No supporting OS subroutines are required.
+ 
+ #include <_ansi.h>
+ #include <string.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t *
+ _DEFUN (wmemmove, (d, s, n),
+diff --git a/source/newlib/libc/string/wmemset.c b/source/newlib/libc/string/wmemset.c
+index 0af6f91..3cc12e4 100644
+--- a/source/newlib/libc/string/wmemset.c
++++ b/source/newlib/libc/string/wmemset.c
+@@ -62,7 +62,7 @@ No supporting OS subroutines are required.
+  */
+ 
+ #include <_ansi.h>
+-#include <wchar.h>
++#include "../include/wchar.h"
+ 
+ wchar_t	*
+ _DEFUN(wmemset, (s, c, n),
+-- 
+1.8.4-mingw-3
+

--- a/msys-core/0018-Add-missing-wchar-prototypes.patch
+++ b/msys-core/0018-Add-missing-wchar-prototypes.patch
@@ -1,0 +1,97 @@
+From 0e39a0c0ffa5d3ac4a65c2711c28c9886146385b Mon Sep 17 00:00:00 2001
+From: Doug Kelly <dougk.ff7@gmail.com>
+Date: Thu, 19 Jun 2014 10:37:20 -0500
+Subject: [PATCH 2/2] Add missing wchar prototypes
+
+wchar as provided by cygwin (and packaged by us) has a number of
+missing prototypes -- add the remainder of prototypes, as well as
+the mbstate_t typedef as it is defined in msys-1.0.dll.
+---
+ source/winsup/cygwin/include/wchar.h | 66 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 66 insertions(+)
+
+diff --git a/source/winsup/cygwin/include/wchar.h b/source/winsup/cygwin/include/wchar.h
+index 682ef3f..cb9db0c 100644
+--- a/source/winsup/cygwin/include/wchar.h
++++ b/source/winsup/cygwin/include/wchar.h
+@@ -19,11 +19,77 @@ details. */
+ #define __need_size_t
+ #include <stddef.h>
+ #include <stdio.h>
++#include <stdarg.h>
++
++#define WCHAR_MIN	0
++#define WCHAR_MAX	0xffff
++
++#ifndef WEOF
++#define	WEOF	(wchar_t)(0xFFFF)
++#endif
++
++typedef struct
++{
++  int __count;
++  union
++  {
++    wint_t __wch;
++    unsigned char __wchb[4];
++  } __value;		/* Value so far.  */
++} mbstate_t;
+ 
+ __BEGIN_DECLS
+ 
++wint_t fgetwc (FILE *stream);
++wchar_t *fgetws (wchar_t *ws, int num, FILE *stream);
++wint_t fputwc (wchar_t wc, FILE *stream);
++int fputws (const wchar_t *ws, FILE *stream);
++int fwide (FILE *stream, int mode);
++int fwprintf (FILE *stream, const wchar_t *format, ...);
++int fwscanf (FILE *stream, const wchar_t *format, ...);
++wint_t getwc (FILE *stream);
++wint_t getwchar (void);
++wint_t putwc (wchar_t wc, FILE *stream);
++wint_t putwchar (wchar_t wc);
++int swprintf (wchar_t *ws, size_t len, const wchar_t *format, ...);
++int swscanf (const wchar_t *ws, const wchar_t *format, ...);
++wint_t ungetwc (wint_t wc, FILE *stream);
++int vfwprintf (FILE *stream, const wchar_t *format, va_list arg);
++int vwprintf (const wchar_t *format, va_list arg);
++int wprintf (const wchar_t *format, ...);
++int wscanf (const wchar_t *format, ...);
++double wcstod (const wchar_t *str, wchar_t **endptr);
++long int wcstol (const wchar_t *str, wchar_t **endptr, int base);
++unsigned long int wcstoul (const wchar_t *str, wchar_t **endptr, int base);
++wint_t btowc (int c);
++size_t mbrlen (const char *pmb, size_t max, mbstate_t *ps);
++size_t mbrtowc (wchar_t *pwc, const char *pmb, size_t max, mbstate_t *ps);
++int mbsinit (const mbstate_t *ps);
++size_t mbsrtowcs (wchar_t *dest, const char **src, size_t max, mbstate_t *ps);
++size_t wcrtomb (char *pmb, wchar_t wc, mbstate_t *ps);
+ int wcscmp (const wchar_t *__s1, const wchar_t *__s2);
+ size_t wcslen (const wchar_t *__s1);
++int wctob (wint_t wc);
++size_t wcsrtombs (char *dest, const wchar_t **src, size_t max, mbstate_t* ps);
++wchar_t *wcscat (wchar_t *destination, const wchar_t *source);
++wchar_t *wcschr(const wchar_t*  ws, wchar_t wc);
++int wcscoll (const wchar_t *wcs1, const wchar_t *wcs2);
++wchar_t *wcscpy (wchar_t *destination, const wchar_t *source);
++size_t wcscspn (const wchar_t *wcs1, const wchar_t* wcs2);
++wchar_t *wcsncat (wchar_t *destination, const wchar_t *source, size_t num);
++int wcsncmp (const wchar_t *wcs1, const wchar_t *wcs2, size_t num);
++wchar_t *wcsncpy (wchar_t *destination, const wchar_t *source, size_t num);
++wchar_t *wcspbrk (const wchar_t *wcs1, const wchar_t *wcs2);
++wchar_t *wcsrchr (const wchar_t *ws, wchar_t wc);
++size_t wcsspn (const wchar_t *wcs1, const wchar_t *wcs2);
++wchar_t *wcsstr (const wchar_t *wcs1, const wchar_t *wcs2);
++wchar_t *wcstok (wchar_t *wcs, const wchar_t *delimiters);
++size_t wcsxfrm (wchar_t *destination, const wchar_t *source, size_t num);
++wchar_t *wmemchr(const wchar_t *ptr, wchar_t wc, size_t num);
++int wmemcmp (const wchar_t *ptr1, const wchar_t *ptr2, size_t num);
++wchar_t *wmemcpy (wchar_t *destination, const wchar_t *source, size_t num);
++wchar_t *wmemmove (wchar_t *destination, const wchar_t *source, size_t num);
++wchar_t *wmemset (wchar_t *ptr, wchar_t wc, size_t num);
+ 
+ __END_DECLS
+ 
+-- 
+1.8.4-mingw-3
+

--- a/msys-core/msysCORE-1.0.18-1.msysport
+++ b/msys-core/msysCORE-1.0.18-1.msysport
@@ -13,7 +13,13 @@ PATCH_URI="0001-Tweak-msys_p2w-for-msysgit.patch
            0007-only-override-the-variables-HOMEPATH-and-HOMEDRIVE-i.patch
            0008-Do-not-start-the-fstab-observer-thread.patch
            0009-spawning-of-processes-combine-for-loops-and-resolve-.patch
-           0011-msys.dll-Don-t-pull-user32.dll-friends-just-to-detec.patch"
+           0011-msys.dll-Don-t-pull-user32.dll-friends-just-to-detec.patch
+           0013-msys.dll-basic-Unicode-support.patch
+           0014-msys.dll-support-Unicode-console-input.patch
+           0015-msys.dll-support-ALT-NUMPAD-console-input.patch
+           0016-msys.dll-backport-multibyte-support-functions-from-n.patch
+           0017-Fix-multibyte-compile-errors.patch
+           0018-Add-missing-wchar-prototypes.patch"
 
 PKG_COMPTYPES="bin ext dev doc lic"
 PKG_CONTENTS[0]="bin/msys-1.0.dll
@@ -52,7 +58,7 @@ PKG_CONTENTS[4]="share/doc/MSYS/COPYING
 
 src_compile() {
   cd ${B}
-  mgwconf
+  mgwconf --enable-newlib-mb
 
   W32API_CPPFLAGS=-I/usr/include/w32api \
   W32API_LDFLAGS=-L/usr/lib/w32api \


### PR DESCRIPTION
This ports in Karsten Blees' Unicode patches, and makes a few minor
changes to build within mingwport.  The resulting msys-1.0.dll is
able to properly handle Unicode characters -- it is possible to
rebuild msys-bash after, but doesn't appear to be necessary.

After this patch (and updating msys-1.0.dll), I found that the only two remaining failed tests were t1508-at-combinations (which uses some really funny branch names), and t5510-fetch (which uses rsync).  So, this seems pretty critical to the overall goal of getting all unit tests passing!
